### PR TITLE
Fix option icon

### DIFF
--- a/icons/option.svg
+++ b/icons/option.svg
@@ -1,4 +1,3 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" class="bi bi-option" viewBox="0 0 20 20">
-  <path stroke="#000" stroke-linecap="round" stroke-linejoin="round" d="M3 4.5h4l6 11h4"/>
-  <path stroke="#000" stroke-linecap="round" d="M17 4.5h-4"/>
+  <path fill-rule="evenodd" d="M2.5 4.5A.5.5 0 013 4h4a.5.5 0 01.439.26L13.297 15H17a.5.5 0 010 1h-4a.5.5 0 01-.439-.26L6.703 5H3a.5.5 0 01-.5-.5zm10 0A.5.5 0 0113 4h4a.5.5 0 010 1h-4a.5.5 0 01-.5-.5z" clip-rule="evenodd"/>
 </svg>


### PR DESCRIPTION
Forgot to convert the paths to shapes in Figma before exporting. This fixes that issue while ensuring the outer `<svg>` element and attributes remain unchanged.