### PR TITLE
build-svgs.js: remove `removeAttr()`.

### DIFF
--- a/build/build-svgs.js
+++ b/build/build-svgs.js
@@ -15,7 +15,6 @@ const pWriteFile = promisify(fs.writeFile)
 const iconsDir = path.join(__dirname, '../icons/')
 
 const svgAttributes = {
-  class: '',
   width: '20',
   height: '20',
   viewBox: '0 0 20 20',
@@ -34,7 +33,6 @@ const processFile = file => new Promise((resolve, reject) => {
       svg.replaceWith(() => $('<svg>').append($(this).html()))
 
       for (const [attr, val] of Object.entries(svgAttributes)) {
-        $(svg).removeAttr(attr)
         $(svg).attr(attr, val)
       }
 


### PR DESCRIPTION
Using `attr()` will overwrite the value anyway.

@Johann-S I was wondering a few things:

1. should we use `prop` or `attr`?
2. for setting the class there's also `addClass` but that will add the class and not wipe any existent ones
3. the `class: ''` seems moot too

@mdo: can you share an icon exactly like it's output without any processing?