### PR TITLE
Update svgo to 1.3.2.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -220,9 +220,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.11.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.11.7.tgz",
-      "integrity": "sha512-JNbGaHFCLwgHn/iCckiGSOZ1XYHsKFwREtzPwSGCVld1SGhOlmZw2D4ZI94HQCrBHbADzW9m4LER/8olJTRGHA==",
+      "version": "12.12.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.0.tgz",
+      "integrity": "sha512-6N8Sa5AaENRtJnpKXZgvc119PKxT1Lk9VPy4kfT8JF23tIe1qDfaGkBR2DRKJFIA7NptMz+fps//C6aLi1Uoug==",
       "dev": true
     },
     "@types/q": {
@@ -1011,9 +1011,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001004",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001004.tgz",
-      "integrity": "sha512-3nfOR4O8Wa2RWoYfJkMtwRVOsK96TQ+eq57wd0iKaEWl8dwG4hKZ/g0MVBfCvysFvMLi9fQGR/DvozMdkEPl3g==",
+      "version": "1.0.30001006",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001006.tgz",
+      "integrity": "sha512-MXnUVX27aGs/QINz+QG1sWSLDr3P1A3Hq5EUWoIt0T7K24DuvMxZEnh3Y5aHlJW6Bz2aApJdSewdYLd8zQnUuw==",
       "dev": true
     },
     "caw": {
@@ -1467,21 +1467,13 @@
       "dev": true
     },
     "css-tree": {
-      "version": "1.0.0-alpha.33",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.33.tgz",
-      "integrity": "sha512-SPt57bh5nQnpsTBsx/IXbO14sRc9xXu5MtMAVuo0BaQQmyf0NupNPPSoMaqiAF5tDFafYsTkfeH4Q/HCKXkg4w==",
+      "version": "1.0.0-alpha.37",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.37.tgz",
+      "integrity": "sha512-DMxWJg0rnz7UgxKT0Q1HU/L9BeJI0M6ksor0OgqOnF+aRCDWg/N2641HmVyU9KVIu0OVVWOb2IpC9A+BJRnejg==",
       "dev": true,
       "requires": {
         "mdn-data": "2.0.4",
-        "source-map": "^0.5.3"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
-        }
+        "source-map": "^0.6.1"
       }
     },
     "css-what": {
@@ -1497,36 +1489,12 @@
       "dev": true
     },
     "csso": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/csso/-/csso-3.5.1.tgz",
-      "integrity": "sha512-vrqULLffYU1Q2tLdJvaCYbONStnfkfimRxXNaGjxMldI0C7JPBC4rB1RyjhfdZ4m1frm8pM9uRPKH3d2knZ8gg==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/csso/-/csso-4.0.2.tgz",
+      "integrity": "sha512-kS7/oeNVXkHWxby5tHVxlhjizRCSv8QdU7hB2FpdAibDU8FjTAolhNjKNTiLzXtUrKT6HwClE81yXwEk1309wg==",
       "dev": true,
       "requires": {
-        "css-tree": "1.0.0-alpha.29"
-      },
-      "dependencies": {
-        "css-tree": {
-          "version": "1.0.0-alpha.29",
-          "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.29.tgz",
-          "integrity": "sha512-sRNb1XydwkW9IOci6iB2xmy8IGCj6r/fr+JWitvJ2JxQRPzN3T4AGGVWCMlVmVwM1gtgALJRmGIlWv5ppnGGkg==",
-          "dev": true,
-          "requires": {
-            "mdn-data": "~1.1.0",
-            "source-map": "^0.5.3"
-          }
-        },
-        "mdn-data": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-1.1.4.tgz",
-          "integrity": "sha512-FSYbp3lyKjyj3E7fMl6rYvUdX0FBXaluGqlFoYESWQlyUTq8R+wp0rkFxoYFqZlHCvsUXGjyJmLQSnXToYhOSA==",
-          "dev": true
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
-        }
+        "css-tree": "1.0.0-alpha.37"
       }
     },
     "currently-unhandled": {
@@ -7107,17 +7075,17 @@
       "dev": true
     },
     "svgo": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-1.3.0.tgz",
-      "integrity": "sha512-MLfUA6O+qauLDbym+mMZgtXCGRfIxyQoeH6IKVcFslyODEe/ElJNwr0FohQ3xG4C6HK6bk3KYPPXwHVJk3V5NQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-1.3.2.tgz",
+      "integrity": "sha512-yhy/sQYxR5BkC98CY7o31VGsg014AKLEPxdfhora76l36hD9Rdy5NZA/Ocn6yayNPgSamYdtX2rFJdcv07AYVw==",
       "dev": true,
       "requires": {
         "chalk": "^2.4.1",
         "coa": "^2.0.2",
         "css-select": "^2.0.0",
         "css-select-base-adapter": "^0.1.1",
-        "css-tree": "1.0.0-alpha.33",
-        "csso": "^3.5.1",
+        "css-tree": "1.0.0-alpha.37",
+        "csso": "^4.0.2",
         "js-yaml": "^3.13.1",
         "mkdirp": "~0.5.1",
         "object.values": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "shx": "^0.3.2",
     "stylelint": "^11.1.1",
     "stylelint-config-twbs-bootstrap": "^0.8.0",
-    "svgo": "^1.3.0",
+    "svgo": "^1.3.2",
     "vnu-jar": "19.9.4"
   },
   "engines": {


### PR DESCRIPTION
@Johann-S there's a bug in svgo 1.3.1, but we really need to improve error handling :/

```
C:\Users\xmr\Desktop\bootstrap-icons>npm run icons

> bootstrap-icons@0.2.0 icons C:\Users\xmr\Desktop\bootstrap-icons
> node build/build-svgs.js

[build-svgs.js] started
(node:1308) UnhandledPromiseRejectionWarning: TypeError: Cannot set property 'multipassCount' of undefined
    at optimizeOnceCallback (C:\Users\xmr\Desktop\bootstrap-icons\node_modules\svgo\lib\svgo.js:41:37)
    at C:\Users\xmr\Desktop\bootstrap-icons\node_modules\svgo\lib\svgo.js:71:9
    at SAXParser.sax.onend (C:\Users\xmr\Desktop\bootstrap-icons\node_modules\svgo\lib\svgo\svg2js.js:169:13)
    at emit (C:\Users\xmr\Desktop\bootstrap-icons\node_modules\sax\lib\sax.js:624:35)
    at end (C:\Users\xmr\Desktop\bootstrap-icons\node_modules\sax\lib\sax.js:667:5)
    at SAXParser.write (C:\Users\xmr\Desktop\bootstrap-icons\node_modules\sax\lib\sax.js:975:14)
    at SAXParser.close (C:\Users\xmr\Desktop\bootstrap-icons\node_modules\sax\lib\sax.js:157:38)
    at module.exports (C:\Users\xmr\Desktop\bootstrap-icons\node_modules\svgo\lib\svgo\svg2js.js:182:28)
    at SVGO._optimizeOnce (C:\Users\xmr\Desktop\bootstrap-icons\node_modules\svgo\lib\svgo.js:63:5)
    at C:\Users\xmr\Desktop\bootstrap-icons\node_modules\svgo\lib\svgo.js:56:14
(node:1308) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 2)
(node:1308) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```