### PR TITLE
Add autocomplete=off to filter/search

### DIFF
--- a/docs/layouts/partials/icons.html
+++ b/docs/layouts/partials/icons.html
@@ -3,7 +3,7 @@
     <h2 id="icons" class="mb-0">Icons</h2>
     <form class="subnav-search d-flex flex-nowrap ml-auto">
       <label for="search" class="sr-only">Search for icons</label>
-      <input class="form-control search mb-0" id="search" placeholder="Start typing to filter...">
+      <input class="form-control search mb-0" id="search" placeholder="Start typing to filter..." autocomplete="off">
     </form>
   </div>
   <ul class="row row-cols-3 row-cols-sm-4 row-cols-lg-6 row-cols-xl-8 list-unstyled list">


### PR DESCRIPTION
I was getting unrelated search terms appearing as a tooltip on focus (from search terms I've used on other sites). Adding `autocomplete="off"` fixes the issue from potentially hitting other users.