### PR TITLE
Fix text-right icon

### DIFF
--- a/icons/text-right.svg
+++ b/icons/text-right.svg
@@ -1,3 +1,3 @@
 <svg class="bi bi-text-right" width="1em" height="1em" viewBox="0 0 20 20" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
-  <path stroke="#000" stroke-linecap="round" d="M8.5 14.5h7m-11-3h11m-7-3h7m-11-3h11"/>
+  <path fill-rule="evenodd" d="M8 14.5a.5.5 0 01.5-.5h7a.5.5 0 010 1h-7a.5.5 0 01-.5-.5zm-4-3a.5.5 0 01.5-.5h11a.5.5 0 010 1h-11a.5.5 0 01-.5-.5zm4-3a.5.5 0 01.5-.5h7a.5.5 0 010 1h-7a.5.5 0 01-.5-.5zm-4-3a.5.5 0 01.5-.5h11a.5.5 0 010 1h-11a.5.5 0 01-.5-.5z" clip-rule="evenodd"/>
 </svg>


### PR DESCRIPTION
Wasn't outlined properly in Figma. Originally called out in #89, fixing with proper re-export and re-running of our scripts.