### PR TITLE
Fix the OpenCollective link in the header

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -49,3 +49,4 @@ params:
   blog:                 "https://blog.getbootstrap.com"
   expo:                 "https://expo.getbootstrap.com"
   themes:               "https://themes.getbootstrap.com"
+  opencollective:       "https://opencollective.com/bootstrap"


### PR DESCRIPTION
Hello, the opencollective parameter didn't exist in the configuration file, so the link to the OpenCollective page in the header was broken.

This was reported by benatkin on [Hacker News](https://news.ycombinator.com/item?id=23544128).