### PR TITLE
Update docs to use filename instead of humanized name

### DIFF
--- a/docs/layouts/partials/icons.html
+++ b/docs/layouts/partials/icons.html
@@ -12,7 +12,6 @@
     {{- range (readDir $dirName) -}}
       {{- $filenameWithExt := split .Name "." -}}
       {{- $filename := index $filenameWithExt 0 -}}
-      {{- $name := humanize $filename -}}
       <li class="col mb-4" data-tags="{{ with $.Site.GetPage "icons" $filename }}{{ with .Params.tags }}{{ delimit . " " }}{{ end }}{{ end }}">
         <a class="d-block text-dark text-decoration-none" href="/icons/{{ $filename }}/">
           <div class="p-3 py-4 mb-2 bg-light text-center rounded">
@@ -21,7 +20,7 @@
             </svg>
           </div>
           <div class="name text-muted text-decoration-none text-center pt-1">
-            {{ $name }}
+            {{ $filename }}
           </div>
         </a>
       </li>


### PR DESCRIPTION
Makes searching easier and allows for some copy-paste action from the homepage in case you just need the file name of the icon you’re trying to use.