### PR TITLE
build-svgs.js: fix UnhandledPromiseRejectionWarning

### DIFF
--- a/build/build-svgs.js
+++ b/build/build-svgs.js
@@ -70,7 +70,7 @@ const processFile = (file, config) => new Promise((resolve, reject) => {
 
           $(svg).attr('class', `bi bi-${path.basename(file, '.svg')}`)
 
-          fs.writeFile(file, $(svg), 'utf8')
+          fs.writeFile(file, $(svg).toString(), 'utf8')
             .then(() => {
               console.log(`- ${path.basename(file, '.svg')}`)
               resolve()


### PR DESCRIPTION
Fixes the following on Node.js 14.x:

```
> bootstrap-icons@1.1.0 icons C:\Users\xmr\Desktop\icons
> node build/build-svgs.js && npm run icons-sprite

[build-svgs.js] started
(node:9900) UnhandledPromiseRejectionWarning: TypeError [ERR_INVALID_ARG_TYPE]: The "data" argument must be of type string or an instance of Buffer, TypedArray, or DataView. Received an instance of initialize
    at Object.writeFile (internal/fs/promises.js:609:5)
    at C:\Users\xmr\Desktop\icons\build\build-svgs.js:73:14
(Use `node --trace-warnings ...` to show where the warning was created)
(node:9900) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 2)
(node:9900) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

I'm going to switch CI to Node.js 14.x in another PR.
