### PR TITLE
Add tags to various icons

### DIFF
--- a/docs/content/icons/app-indicator.md
+++ b/docs/content/icons/app-indicator.md
@@ -8,4 +8,5 @@ tags:
   - ios
   - android
   - notification
+  - square
 ---

--- a/docs/content/icons/app.md
+++ b/docs/content/icons/app.md
@@ -7,4 +7,5 @@ tags:
   - application
   - ios
   - android
+  - square
 ---

--- a/docs/content/icons/bookmark-check-fill.md
+++ b/docs/content/icons/bookmark-check-fill.md
@@ -5,4 +5,7 @@ categories:
 tags:
   - reading
   - book
+  - label
+  - tag
+  - category
 ---

--- a/docs/content/icons/bookmark-check.md
+++ b/docs/content/icons/bookmark-check.md
@@ -5,4 +5,7 @@ categories:
 tags:
   - reading
   - book
+  - label
+  - tag
+  - category
 ---

--- a/docs/content/icons/bookmark-dash-fill.md
+++ b/docs/content/icons/bookmark-dash-fill.md
@@ -5,4 +5,7 @@ categories:
 tags:
   - reading
   - book
+  - label
+  - tag
+  - category
 ---

--- a/docs/content/icons/bookmark-dash.md
+++ b/docs/content/icons/bookmark-dash.md
@@ -5,4 +5,7 @@ categories:
 tags:
   - reading
   - book
+  - label
+  - tag
+  - category
 ---

--- a/docs/content/icons/bookmark-fill.md
+++ b/docs/content/icons/bookmark-fill.md
@@ -5,4 +5,7 @@ categories:
 tags:
   - reading
   - book
+  - label
+  - tag
+  - category
 ---

--- a/docs/content/icons/bookmark-heart-fill.md
+++ b/docs/content/icons/bookmark-heart-fill.md
@@ -5,4 +5,7 @@ categories:
 tags:
   - reading
   - book
+  - label
+  - tag
+  - category
 ---

--- a/docs/content/icons/bookmark-heart.md
+++ b/docs/content/icons/bookmark-heart.md
@@ -5,4 +5,7 @@ categories:
 tags:
   - reading
   - book
+  - label
+  - tag
+  - category
 ---

--- a/docs/content/icons/bookmark-plus-fill.md
+++ b/docs/content/icons/bookmark-plus-fill.md
@@ -5,4 +5,7 @@ categories:
 tags:
   - reading
   - book
+  - label
+  - tag
+  - category
 ---

--- a/docs/content/icons/bookmark-plus.md
+++ b/docs/content/icons/bookmark-plus.md
@@ -5,4 +5,7 @@ categories:
 tags:
   - reading
   - book
+  - label
+  - tag
+  - category
 ---

--- a/docs/content/icons/bookmark-star-fill.md
+++ b/docs/content/icons/bookmark-star-fill.md
@@ -5,4 +5,7 @@ categories:
 tags:
   - reading
   - book
+  - label
+  - tag
+  - category
 ---

--- a/docs/content/icons/bookmark-star.md
+++ b/docs/content/icons/bookmark-star.md
@@ -5,4 +5,7 @@ categories:
 tags:
   - reading
   - book
+  - label
+  - tag
+  - category
 ---

--- a/docs/content/icons/bookmark-x-fill.md
+++ b/docs/content/icons/bookmark-x-fill.md
@@ -5,4 +5,7 @@ categories:
 tags:
   - reading
   - book
+  - label
+  - tag
+  - category
 ---

--- a/docs/content/icons/bookmark-x.md
+++ b/docs/content/icons/bookmark-x.md
@@ -5,4 +5,7 @@ categories:
 tags:
   - reading
   - book
+  - label
+  - tag
+  - category
 ---

--- a/docs/content/icons/bookmark.md
+++ b/docs/content/icons/bookmark.md
@@ -5,4 +5,7 @@ categories:
 tags:
   - reading
   - book
+  - label
+  - tag
+  - category
 ---

--- a/docs/content/icons/bookmarks-fill.md
+++ b/docs/content/icons/bookmarks-fill.md
@@ -5,4 +5,7 @@ categories:
 tags:
   - reading
   - book
+  - label
+  - tag
+  - category
 ---

--- a/docs/content/icons/bookmarks.md
+++ b/docs/content/icons/bookmarks.md
@@ -5,4 +5,7 @@ categories:
 tags:
   - reading
   - book
+  - label
+  - tag
+  - category
 ---

--- a/docs/content/icons/box-arrow-in-left.md
+++ b/docs/content/icons/box-arrow-in-left.md
@@ -4,4 +4,7 @@ categories:
   - Box arrows
 tags:
   - arrow
+  - login
+  - signin
+  - enter
 ---

--- a/docs/content/icons/box-arrow-in-right.md
+++ b/docs/content/icons/box-arrow-in-right.md
@@ -4,4 +4,7 @@ categories:
   - Box arrows
 tags:
   - arrow
+  - login
+  - signin
+  - enter
 ---

--- a/docs/content/icons/box-arrow-left.md
+++ b/docs/content/icons/box-arrow-left.md
@@ -4,4 +4,7 @@ categories:
   - Box arrows
 tags:
   - arrow
+  - logout
+  - signout
+  - exit
 ---

--- a/docs/content/icons/box-arrow-right.md
+++ b/docs/content/icons/box-arrow-right.md
@@ -4,4 +4,7 @@ categories:
   - Box arrows
 tags:
   - arrow
+  - logout
+  - signout
+  - exit
 ---

--- a/docs/content/icons/brightness-alt-high-fill.md
+++ b/docs/content/icons/brightness-alt-high-fill.md
@@ -4,4 +4,6 @@ categories:
   - UI and keyboard
 tags:
   - brightness
+  - sun
+  - weather
 ---

--- a/docs/content/icons/brightness-alt-high.md
+++ b/docs/content/icons/brightness-alt-high.md
@@ -4,4 +4,6 @@ categories:
   - UI and keyboard
 tags:
   - brightness
+  - sun
+  - weather
 ---

--- a/docs/content/icons/brightness-high-fill.md
+++ b/docs/content/icons/brightness-high-fill.md
@@ -4,4 +4,6 @@ categories:
   - UI and keyboard
 tags:
   - brightness
+  - sun
+  - weather
 ---

--- a/docs/content/icons/brightness-high.md
+++ b/docs/content/icons/brightness-high.md
@@ -4,4 +4,6 @@ categories:
   - UI and keyboard
 tags:
   - brightness
+  - sun
+  - weather
 ---

--- a/docs/content/icons/compass-fill.md
+++ b/docs/content/icons/compass-fill.md
@@ -5,4 +5,5 @@ categories:
 tags:
   - direction
   - map
+  - location
 ---

--- a/docs/content/icons/compass.md
+++ b/docs/content/icons/compass.md
@@ -5,4 +5,5 @@ categories:
 tags:
   - direction
   - map
+  - location
 ---

--- a/docs/content/icons/gear-fill.md
+++ b/docs/content/icons/gear-fill.md
@@ -4,4 +4,6 @@ categories:
   - Tools
 tags:
   - tool
+  - settings
+  - preferences
 ---

--- a/docs/content/icons/gear-wide-connected.md
+++ b/docs/content/icons/gear-wide-connected.md
@@ -4,4 +4,6 @@ categories:
   - Tools
 tags:
   - tool
+  - settings
+  - preferences
 ---

--- a/docs/content/icons/gear-wide.md
+++ b/docs/content/icons/gear-wide.md
@@ -4,4 +4,6 @@ categories:
   - Tools
 tags:
   - tool
+  - settings
+  - preferences
 ---

--- a/docs/content/icons/gear.md
+++ b/docs/content/icons/gear.md
@@ -4,4 +4,6 @@ categories:
   - Tools
 tags:
   - tool
+  - settings
+  - preferences
 ---

--- a/docs/content/icons/geo-alt-fill.md
+++ b/docs/content/icons/geo-alt-fill.md
@@ -1,5 +1,10 @@
 ---
 title: Geo alt fill
 categories:
+  - Geo
 tags:
+  - geography
+  - map
+  - pin
+  - location
 ---

--- a/docs/content/icons/geo-alt.md
+++ b/docs/content/icons/geo-alt.md
@@ -6,4 +6,5 @@ tags:
   - geography
   - map
   - pin
+  - location
 ---

--- a/docs/content/icons/geo-fill.md
+++ b/docs/content/icons/geo-fill.md
@@ -6,4 +6,5 @@ tags:
   - geography
   - map
   - pin
+  - location
 ---

--- a/docs/content/icons/geo.md
+++ b/docs/content/icons/geo.md
@@ -6,4 +6,5 @@ tags:
   - geography
   - map
   - pin
+  - location
 ---

--- a/docs/content/icons/map-fill.md
+++ b/docs/content/icons/map-fill.md
@@ -5,4 +5,5 @@ categories:
 tags:
   - geography
   - directions
+  - location
 ---

--- a/docs/content/icons/map.md
+++ b/docs/content/icons/map.md
@@ -5,4 +5,5 @@ categories:
 tags:
   - geography
   - directions
+  - location
 ---

--- a/docs/content/icons/moon.md
+++ b/docs/content/icons/moon.md
@@ -5,4 +5,5 @@ categories:
 tags:
   - lunar
   - weather
+  - night
 ---

--- a/docs/content/icons/people-fill.md
+++ b/docs/content/icons/people-fill.md
@@ -6,4 +6,5 @@ tags:
   - humans
   - organization
   - avatar
+  - users
 ---

--- a/docs/content/icons/people.md
+++ b/docs/content/icons/people.md
@@ -6,4 +6,5 @@ tags:
   - humans
   - organization
   - avatar
+  - users
 ---

--- a/docs/content/icons/person-badge-fill.md
+++ b/docs/content/icons/person-badge-fill.md
@@ -6,6 +6,7 @@ tags:
   - human
   - individual
   - avatar
+  - user
   - badge
   - id
   - card

--- a/docs/content/icons/person-badge.md
+++ b/docs/content/icons/person-badge.md
@@ -6,6 +6,7 @@ tags:
   - human
   - individual
   - avatar
+  - user
   - badge
   - id
   - card

--- a/docs/content/icons/person-bounding-box.md
+++ b/docs/content/icons/person-bounding-box.md
@@ -6,5 +6,6 @@ tags:
   - human
   - individual
   - avatar
+  - user
   - crop
 ---

--- a/docs/content/icons/person-check-fill.md
+++ b/docs/content/icons/person-check-fill.md
@@ -6,5 +6,6 @@ tags:
   - human
   - individual
   - avatar
+  - user
   - verified
 ---

--- a/docs/content/icons/person-check.md
+++ b/docs/content/icons/person-check.md
@@ -6,5 +6,6 @@ tags:
   - human
   - individual
   - avatar
+  - user
   - verified
 ---

--- a/docs/content/icons/person-circle.md
+++ b/docs/content/icons/person-circle.md
@@ -6,4 +6,5 @@ tags:
   - humans
   - organization
   - avatar
+  - user
 ---

--- a/docs/content/icons/person-dash-fill.md
+++ b/docs/content/icons/person-dash-fill.md
@@ -6,6 +6,7 @@ tags:
   - human
   - individual
   - avatar
+  - user
   - remove
   - delete
 ---

--- a/docs/content/icons/person-dash.md
+++ b/docs/content/icons/person-dash.md
@@ -6,6 +6,7 @@ tags:
   - human
   - individual
   - avatar
+  - user
   - remove
   - delete
 ---

--- a/docs/content/icons/person-fill.md
+++ b/docs/content/icons/person-fill.md
@@ -6,4 +6,5 @@ tags:
   - human
   - individual
   - avatar
+  - user
 ---

--- a/docs/content/icons/person-lines-fill.md
+++ b/docs/content/icons/person-lines-fill.md
@@ -6,6 +6,7 @@ tags:
   - human
   - individual
   - avatar
+  - user
   - contact
   - list
 ---

--- a/docs/content/icons/person-plus-fill.md
+++ b/docs/content/icons/person-plus-fill.md
@@ -6,6 +6,7 @@ tags:
   - human
   - individual
   - avatar
+  - user
   - new
   - add
 ---

--- a/docs/content/icons/person-plus.md
+++ b/docs/content/icons/person-plus.md
@@ -6,6 +6,7 @@ tags:
   - human
   - individual
   - avatar
+  - user
   - new
   - add
 ---

--- a/docs/content/icons/person-square.md
+++ b/docs/content/icons/person-square.md
@@ -6,4 +6,5 @@ tags:
   - human
   - individual
   - avatar
+  - user
 ---

--- a/docs/content/icons/person-x-fill.md
+++ b/docs/content/icons/person-x-fill.md
@@ -6,6 +6,7 @@ tags:
   - human
   - individual
   - avatar
+  - user
   - remove
   - delete
 ---

--- a/docs/content/icons/person-x.md
+++ b/docs/content/icons/person-x.md
@@ -6,6 +6,7 @@ tags:
   - human
   - individual
   - avatar
+  - user
   - remove
   - delete
 ---

--- a/docs/content/icons/person.md
+++ b/docs/content/icons/person.md
@@ -6,4 +6,5 @@ tags:
   - human
   - individual
   - avatar
+  - user
 ---

--- a/docs/content/icons/search.md
+++ b/docs/content/icons/search.md
@@ -4,4 +4,5 @@ categories:
   - Communications
 tags:
   - magnifying-glass
+  - look
 ---

--- a/docs/content/icons/tag-fill.md
+++ b/docs/content/icons/tag-fill.md
@@ -6,4 +6,5 @@ tags:
   - price
   - category
   - taxonomy
+  - label
 ---

--- a/docs/content/icons/tag.md
+++ b/docs/content/icons/tag.md
@@ -6,4 +6,5 @@ tags:
   - price
   - category
   - taxonomy
+  - label
 ---

--- a/docs/content/icons/tags-fill.md
+++ b/docs/content/icons/tags-fill.md
@@ -6,4 +6,5 @@ tags:
   - price
   - category
   - taxonomy
+  - label
 ---

--- a/docs/content/icons/tags.md
+++ b/docs/content/icons/tags.md
@@ -6,4 +6,5 @@ tags:
   - price
   - category
   - taxonomy
+  - label
 ---

--- a/docs/content/icons/three-dots-vertical.md
+++ b/docs/content/icons/three-dots-vertical.md
@@ -3,7 +3,9 @@ title: Three dots vertical
 categories:
   - Controls
 tags:
-  - kebab
+  - meatballs
   - more
   - ellipsis
+  - overflow
+  - menu
 ---

--- a/docs/content/icons/three-dots-vertical.md
+++ b/docs/content/icons/three-dots-vertical.md
@@ -3,7 +3,7 @@ title: Three dots vertical
 categories:
   - Controls
 tags:
-  - meatballs
+  - kebab
   - more
   - ellipsis
   - overflow

--- a/docs/content/icons/three-dots.md
+++ b/docs/content/icons/three-dots.md
@@ -6,4 +6,6 @@ tags:
   - kebab
   - more
   - ellipsis
+  - overflow
+  - menu
 ---

--- a/docs/content/icons/three-dots.md
+++ b/docs/content/icons/three-dots.md
@@ -3,7 +3,7 @@ title: Three dots
 categories:
   - Controls
 tags:
-  - kebab
+  - meatballs
   - more
   - ellipsis
   - overflow

--- a/docs/content/icons/x-circle-fill.md
+++ b/docs/content/icons/x-circle-fill.md
@@ -7,4 +7,7 @@ tags:
   - delete
   - reset
   - clear
+  - cancel
+  - close
+  - exit
 ---

--- a/docs/content/icons/x-circle.md
+++ b/docs/content/icons/x-circle.md
@@ -7,4 +7,7 @@ tags:
   - delete
   - reset
   - clear
+  - cancel
+  - close
+  - exit
 ---

--- a/docs/content/icons/x-diamond-fill.md
+++ b/docs/content/icons/x-diamond-fill.md
@@ -7,4 +7,7 @@ tags:
   - delete
   - reset
   - clear
+  - cancel
+  - close
+  - exit
 ---

--- a/docs/content/icons/x-diamond.md
+++ b/docs/content/icons/x-diamond.md
@@ -7,4 +7,7 @@ tags:
   - delete
   - reset
   - clear
+  - cancel
+  - close
+  - exit
 ---

--- a/docs/content/icons/x-octagon-fill.md
+++ b/docs/content/icons/x-octagon-fill.md
@@ -7,4 +7,7 @@ tags:
   - delete
   - reset
   - clear
+  - cancel
+  - close
+  - exit
 ---

--- a/docs/content/icons/x-octagon.md
+++ b/docs/content/icons/x-octagon.md
@@ -7,4 +7,7 @@ tags:
   - delete
   - reset
   - clear
+  - cancel
+  - close
+  - exit
 ---

--- a/docs/content/icons/x-square-fill.md
+++ b/docs/content/icons/x-square-fill.md
@@ -7,4 +7,7 @@ tags:
   - delete
   - reset
   - clear
+  - cancel
+  - close
+  - exit
 ---

--- a/docs/content/icons/x-square.md
+++ b/docs/content/icons/x-square.md
@@ -7,4 +7,7 @@ tags:
   - delete
   - reset
   - clear
+  - cancel
+  - close
+  - exit
 ---

--- a/docs/content/icons/x.md
+++ b/docs/content/icons/x.md
@@ -7,4 +7,7 @@ tags:
   - delete
   - reset
   - clear
+  - cancel
+  - close
+  - exit
 ---


### PR DESCRIPTION
This PR adds additional tags to various icons, to make them better findable. I recently created a couple of new sites and had a hard time finding various icons.

Note that in `three-dots` the tag `kebab` is replaced with `meatballs`. That is the [unofficial name](https://ux.stackexchange.com/a/115469) when these dots are used for a menu. The tags `overflow` is based on the [Android docs](https://material.io/components/app-bars-top#anatomy).

It also fixes #148 because the login and logout icons that are requested are already in the collection (`box-arrow-in-right` and `box-arrow-right`). They are just hard to find, but with the added tags that should be solved. I added the `login` and `logout` tags to the left variants as well. Not sure how it works, but possibly in RTL languages the left variants can be useful.

Fixes #455 
Fixes #148