### PR TITLE
build-svgs: more tweaks

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -9,6 +9,7 @@
   },
   "extends": "eslint:recommended",
   "rules": {
+    "no-return-await": "error",
     "object-curly-spacing": [
       "error",
       "always"
@@ -17,6 +18,7 @@
     "semi": [
       "error",
       "never"
-    ]
+    ],
+    "strict": "error"
   }
 }


### PR DESCRIPTION
* change `process.argv` to `includes()`; should work with multiple arguments if we decide to add them later
* switch to function declarations
* remove redundant return await
* catch errors in `processFile()`
* add missing `await` in cheerio.load

Refs #50 