### PR TITLE
hero: remove `loading=lazy`

### DIFF
--- a/docs/layouts/partials/hero.html
+++ b/docs/layouts/partials/hero.html
@@ -5,7 +5,7 @@
         <img srcset="/assets/img/icons-hero.png, /assets/img/icons-hero@2x.png 2x"
              src="/assets/img/icons-hero.png"
              class="img-fluid my-3 mx-auto"
-             alt="Bootstrap Icons" width="450" height="340" loading="lazy">
+             alt="Bootstrap Icons" width="450" height="340">
       </div>
       <div class="col-lg-7">
         <a class="d-block d-sm-inline-block py-1 px-3 mb-4 text-dark text-decoration-none rounded-3 hero-notice" href="{{ .Site.Params.blog }}/2020/12/11/bootstrap-icons-1-2-0/">


### PR DESCRIPTION
The image is always in the viewport on page load so we should load it ASAP