### PR TITLE
Remove quickstart link

### DIFF
--- a/docs/layouts/partials/hero.html
+++ b/docs/layouts/partials/hero.html
@@ -29,8 +29,6 @@
           <span class="px-1">&#8226;</span>
           <a href="#install">Install</a>
           <span class="px-1">&#8226;</span>
-          <a href="#quickstart">Quickstart</a>
-          <span class="px-1">&#8226;</span>
           <a href="#usage">Usage</a>
           <span class="px-1">&#8226;</span>
           <a href="#styling">Styling</a>


### PR DESCRIPTION
doesn't seem to be anything with `#quickstart` identifier/anchor in the page