### PR TITLE
Change font priority

### DIFF
--- a/font/bootstrap-icons.css
+++ b/font/bootstrap-icons.css
@@ -1,7 +1,7 @@
 @font-face {
   font-family: "bootstrap-icons";
-  src: url("./fonts/bootstrap-icons.woff?4601c71fb26c9277391ec80789bfde9c") format("woff"),
-url("./fonts/bootstrap-icons.woff2?4601c71fb26c9277391ec80789bfde9c") format("woff2");
+  src: url("./fonts/bootstrap-icons.woff2?4601c71fb26c9277391ec80789bfde9c") format("woff2"),
+       url("./fonts/bootstrap-icons.woff?4601c71fb26c9277391ec80789bfde9c") format("woff");
 }
 
 [class^="bi-"]::before,


### PR DESCRIPTION
The font-family property specifies a list of fonts, from highest priority to lowest. 

Currently woff2 file have size of 78 KiB, woff 104 KiB.
Browser by default is loading first available font from list.

PS: no idea how to use build here

More info:
- https://caniuse.com/woff2
- https://developer.mozilla.org/en-US/docs/Web/CSS/font-family

