### PR TITLE
icons.html: query the icons pages instead of the filesystem

### DIFF
--- a/docs/layouts/icons/single.html
+++ b/docs/layouts/icons/single.html
@@ -27,9 +27,6 @@
 
       <hr class="my-4">
 
-      {{- $filenameWithExt := split .Name "." -}}
-      {{- $filename := index $filenameWithExt 0 -}}
-      {{- $name := humanize $filename -}}
       {{- $svgPath := printf "/icons/%s.svg" .File.TranslationBaseName -}}
       {{- $svgHtml := readFile $svgPath | chomp | safeHTML -}}
 

--- a/docs/layouts/partials/icons.html
+++ b/docs/layouts/partials/icons.html
@@ -7,9 +7,7 @@
     </form>
   </div>
   <ul class="row row-cols-3 row-cols-sm-4 row-cols-lg-6 row-cols-xl-8 list-unstyled list">
-    {{ $dirName := "icons" -}}
-
-    {{- range (readDir $dirName) -}}
+    {{ range (readDir "icons") -}}
       {{- $filenameWithExt := split .Name "." -}}
       {{- $filename := index $filenameWithExt 0 -}}
       <li class="col mb-4" data-tags="{{ with $.Site.GetPage "icons" $filename }}{{ with .Params.tags }}{{ delimit . " " }}{{ end }}{{ end }}">

--- a/docs/layouts/partials/icons.html
+++ b/docs/layouts/partials/icons.html
@@ -7,9 +7,8 @@
     </form>
   </div>
   <ul class="row row-cols-3 row-cols-sm-4 row-cols-lg-6 row-cols-xl-8 list-unstyled list">
-    {{ range (readDir "icons") -}}
-      {{- $filenameWithExt := split .Name "." -}}
-      {{- $filename := index $filenameWithExt 0 -}}
+    {{ range (where site.RegularPages "Type" "icons") -}}
+      {{- $filename := .File.TranslationBaseName -}}
       <li class="col mb-4"{{ with $.Site.GetPage "icons" $filename }}{{ with .Params.tags }} data-tags="{{ delimit . " " }}"{{ end }}{{ end }}>
         <a class="d-block text-dark text-decoration-none" href="/icons/{{ $filename }}/">
           <div class="p-3 py-4 mb-2 bg-light text-center rounded">

--- a/docs/layouts/partials/icons.html
+++ b/docs/layouts/partials/icons.html
@@ -10,7 +10,7 @@
     {{ range (readDir "icons") -}}
       {{- $filenameWithExt := split .Name "." -}}
       {{- $filename := index $filenameWithExt 0 -}}
-      <li class="col mb-4" data-tags="{{ with $.Site.GetPage "icons" $filename }}{{ with .Params.tags }}{{ delimit . " " }}{{ end }}{{ end }}">
+      <li class="col mb-4"{{ with $.Site.GetPage "icons" $filename }}{{ with .Params.tags }} data-tags="{{ delimit . " " }}"{{ end }}{{ end }}>
         <a class="d-block text-dark text-decoration-none" href="/icons/{{ $filename }}/">
           <div class="p-3 py-4 mb-2 bg-light text-center rounded">
             <svg class="bi" width="1em" height="1em" fill="currentColor">


### PR DESCRIPTION
Depends on #704.

I think it makes more sense to do this than looping through the existent SVG files, because we expect each SVGto have a docs page.