### PR TITLE
Move icons to assets/icons

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -34,7 +34,7 @@ module:
     - source:           bootstrap-icons.svg
       target:           static/bootstrap-icons.svg
     - source:           icons
-      target:           static/icons
+      target:           static/assets/icons
     - source:           font
       target:           static/font
 

--- a/docs/layouts/icons/single.html
+++ b/docs/layouts/icons/single.html
@@ -27,8 +27,9 @@
 
       <hr class="my-4">
 
-      {{- $svgPath := printf "/icons/%s.svg" .File.TranslationBaseName -}}
-      {{- $svgHtml := readFile $svgPath | chomp | safeHTML -}}
+      {{- $localSvgPath := printf "/icons/%s.svg" .File.TranslationBaseName -}}
+      {{- $svgPath := path.Join "/assets/" $localSvgPath -}}
+      {{- $svgHtml := readFile $localSvgPath | chomp | safeHTML -}}
 
       <div class="row gx-lg-5">
         <div class="col-lg-8 mb-4">


### PR DESCRIPTION
I think it makes more sense since right now the icons are mounted to the same directory as the content. We could move the font later too after the other PRs land.