### PR TITLE
docs: filter url search query

### DIFF
--- a/docs/assets/js/list.js
+++ b/docs/assets/js/list.js
@@ -3,7 +3,9 @@
 (function () {
   'use strict'
 
-  new List('icons-body', {
+  const searchInput = document.querySelector('#icons-body #search')
+  const query = new URLSearchParams(window.location.search).get('q')
+  const iconList = new List('icons-body', {
     searchDelay: 250,
     valueNames: [
       'name', {
@@ -13,5 +15,24 @@
         ]
       }
     ]
+  })
+
+  if (query) {
+    document.querySelector('#content').scrollIntoView()
+    searchInput.value = query
+    iconList.search(query)
+  }
+
+  iconList.on('searchComplete', () => {
+    const searchTerm = searchInput.value
+    const newUrl = new URL(window.location)
+
+    if (searchTerm.length > 0) {
+      newUrl.searchParams.set('q', searchTerm)
+    } else {
+      newUrl.searchParams.delete('q')
+    }
+
+    window.history.replaceState(null, null, newUrl)
   })
 })()


### PR DESCRIPTION
This fixes #192.
It's currently not possible to get the search term via list.js so I took the search term directly from the input.
The url query will update whenever the search term changes.

Example: https://deploy-preview-731--bootstrap-icons.netlify.app/?q=brand