### PR TITLE
Fix github icon in accessibility examples

### DIFF
--- a/docs/assets/scss/docs.scss
+++ b/docs/assets/scss/docs.scss
@@ -178,5 +178,5 @@
 }
 
 .bi-alarm::before { content: "\f102"; }
-.bi-github::before { content: "\f3cd"; }
+.bi-github::before { content: "\f3ed"; }
 // stylelint-enable


### PR DESCRIPTION
seems that more icons/glyphs were added, and the content point for the github icon moved