### PR TITLE
Docs: Update example GitHub icon to use the correct code point

### DIFF
--- a/docs/assets/scss/docs.scss
+++ b/docs/assets/scss/docs.scss
@@ -178,5 +178,5 @@
 }
 
 .bi-alarm::before { content: "\f102"; }
-.bi-github::before { content: "\f3cd"; }
+.bi-github::before { content: "\f3ed"; }
 // stylelint-enable


### PR DESCRIPTION
In the second example in the accessibility section, there is supposed to be the GitHub logo (U+F3ED), but due to a typo in `docs.scss`, it displays `flower1` instead (U+F3CD).

Here's the canonical reference:

https://github.com/twbs/icons/blob/f364cb14dfc0703b9e3ef10c8b490a71dfef1e9d/font/bootstrap-icons.css#L769