### PR TITLE
Import existing codepoints for icon font

### DIFF
--- a/.fantasticonrc.js
+++ b/.fantasticonrc.js
@@ -1,4 +1,4 @@
-const codepoints = require("./font/bootstrap-icons.json");
+const codepoints = require('./font/bootstrap-icons.json');
 
 module.exports = {
   inputDir: './icons', // (required)
@@ -6,12 +6,12 @@ module.exports = {
   fontTypes: ['woff2', 'woff'],
   assetTypes: ['css', 'json', 'html'],
   name: 'bootstrap-icons',
+  codepoints: codepoints,
   prefix: 'bi',
   selector: '.bi',
   fontsUrl: './fonts',
   formatOptions: {
     json: {
-      // render the JSON human readable with two spaces indentation (default is none, so minified)
       indent: 2
     }
   },
@@ -28,6 +28,5 @@ module.exports = {
     woff: './font/fonts/bootstrap-icons.woff',
     woff2: './font/fonts/bootstrap-icons.woff2',
     eot: './font/fonts/bootstrap-icons.eot'
-  },
-  codepoints: codepoints
+  }
 };

--- a/.fantasticonrc.js
+++ b/.fantasticonrc.js
@@ -1,3 +1,5 @@
+const codepoints = require("./font/bootstrap-icons.json");
+
 module.exports = {
   inputDir: './icons', // (required)
   outputDir: './font', // (required)
@@ -26,5 +28,6 @@ module.exports = {
     woff: './font/fonts/bootstrap-icons.woff',
     woff2: './font/fonts/bootstrap-icons.woff2',
     eot: './font/fonts/bootstrap-icons.eot'
-  }
+  },
+  codepoints: codepoints
 };


### PR DESCRIPTION
Per suggestion in #799, this imports the existing JSON file to ensure that when we add new icons, we only add to the codepoints instead of randomly generating them and potentially causing breaking changes.

Tested on some upcoming icons:

```diff
diff --git a/font/bootstrap-icons.json b/font/bootstrap-icons.json
index e07ab025..e90a3d5b 100644
--- a/font/bootstrap-icons.json
+++ b/font/bootstrap-icons.json
@@ -1323,5 +1323,9 @@
   "x": 63018,
   "youtube": 63019,
   "zoom-in": 63020,
-  "zoom-out": 63021
+  "zoom-out": 63021,
+  "currency-dollar": 63022,
+  "currency-euro": 63023,
+  "currency-pound": 63024,
+  "currency-yen": 63025
 }
\ No newline at end of file
```

---

Fixes #799.