### PR TITLE
Consolidate .bi styles in our docs

### DIFF
--- a/docs/assets/scss/docs.scss
+++ b/docs/assets/scss/docs.scss
@@ -7,6 +7,13 @@
 @import "syntax";
 @import "ads";
 
+.bi {
+  display: inline-block;
+  width: 1em;
+  height: 1em;
+  vertical-align: -.125em;
+}
+
 .hero-notice {
   background-color: $teal-100;
 
@@ -101,11 +108,6 @@
   }
   // stylelint-enable  declaration-no-important
 
-  .bi {
-    display: inline-block;
-    vertical-align: -.125em;
-  }
-
   &:empty::before {
     display: block;
     width: 100%;
@@ -135,12 +137,6 @@
       max-width: 12.5%;
     }
   }
-}
-
-.icon-examples .bi {
-  width: 1em;
-  height: 1em;
-  vertical-align: -.125em;
 }
 
 .icon-demo {

--- a/docs/assets/scss/docs.scss
+++ b/docs/assets/scss/docs.scss
@@ -9,8 +9,6 @@
 
 .bi {
   display: inline-block;
-  width: 1em;
-  height: 1em;
   vertical-align: -.125em;
 }
 


### PR DESCRIPTION
Consolidates the `vertical-align` and more for `.bi` in a global class for our docs, which in turn fixes the copy icon being too low in the homepage hero.