### PR TITLE
Add font-display swap to font face

### DIFF
--- a/font/bootstrap-icons.css
+++ b/font/bootstrap-icons.css
@@ -2,6 +2,7 @@
   font-family: "bootstrap-icons";
   src: url("./fonts/bootstrap-icons.woff2?231ce25e89ab5804f9a6c427b8d325c9") format("woff2"),
 url("./fonts/bootstrap-icons.woff?231ce25e89ab5804f9a6c427b8d325c9") format("woff");
+  font-display: swap;
 }
 
 [class^="bi-"]::before,


### PR DESCRIPTION
Adding font-display: swap; to font face to add "visible text" lighthouse compliancy to bootstrap icons.

https://web.dev/font-display/?utm_source=lighthouse&utm_medium=lr