### PR TITLE
Rename category Social to Brand

### DIFF
--- a/docs/content/icons/discord.md
+++ b/docs/content/icons/discord.md
@@ -1,6 +1,8 @@
 ---
 title: Discord
 categories:
-  - Social
+  - Brand
 tags:
+  - social
+  - chat
 ---

--- a/docs/content/icons/facebook.md
+++ b/docs/content/icons/facebook.md
@@ -1,6 +1,7 @@
 ---
 title: Facebook
 categories:
-  - Social
+  - Brand
 tags:
+  - social
 ---

--- a/docs/content/icons/github.md
+++ b/docs/content/icons/github.md
@@ -1,6 +1,8 @@
 ---
 title: GitHub
 categories:
-  - Social
+  - Brand
 tags:
+  - social
+  - microsoft
 ---

--- a/docs/content/icons/google.md
+++ b/docs/content/icons/google.md
@@ -1,6 +1,8 @@
 ---
 title: Google
 categories:
-  - Social
+  - Brand
 tags:
+  - social
+  - search
 ---

--- a/docs/content/icons/instagram.md
+++ b/docs/content/icons/instagram.md
@@ -1,6 +1,8 @@
 ---
 title: Instagram
 categories:
-  - Social
+  - Brand
 tags:
+  - social
+  - chat
 ---

--- a/docs/content/icons/linkedin.md
+++ b/docs/content/icons/linkedin.md
@@ -1,6 +1,8 @@
 ---
 title: Linkedin
 categories:
-  - Social
+  - Brand
 tags:
+  - social
+  - microsoft
 ---

--- a/docs/content/icons/mastodon.md
+++ b/docs/content/icons/mastodon.md
@@ -1,6 +1,7 @@
 ---
 title: Mastodon
 categories:
-  - Social
+  - Brand
 tags:
+  - social
 ---

--- a/docs/content/icons/messenger.md
+++ b/docs/content/icons/messenger.md
@@ -1,6 +1,9 @@
 ---
 title: Messenger
 categories:
-  - Social
+  - Brand
 tags:
+  - social
+  - facebook
+  - chat
 ---

--- a/docs/content/icons/reddit.md
+++ b/docs/content/icons/reddit.md
@@ -1,6 +1,7 @@
 ---
 title: Reddit
 categories:
-  - Social
+  - Brand
 tags:
+  - social
 ---

--- a/docs/content/icons/skype.md
+++ b/docs/content/icons/skype.md
@@ -1,6 +1,8 @@
 ---
 title: Skype
 categories:
-  - Social
+  - Brand
 tags:
+  - social
+  - microsoft
 ---

--- a/docs/content/icons/slack.md
+++ b/docs/content/icons/slack.md
@@ -1,6 +1,7 @@
 ---
 title: Slack
 categories:
-  - Social
+  - Brand
 tags:
+  - social
 ---

--- a/docs/content/icons/telegram.md
+++ b/docs/content/icons/telegram.md
@@ -1,7 +1,8 @@
 ---
 title: Telegram
 categories:
-  - Social
+  - Brand
 tags:
-  - telegram
+  - social
+  - chat
 ---

--- a/docs/content/icons/twitch.md
+++ b/docs/content/icons/twitch.md
@@ -1,6 +1,7 @@
 ---
 title: Twitch
 categories:
-  - Social
+  - Brand
 tags:
+  - social
 ---

--- a/docs/content/icons/twitter.md
+++ b/docs/content/icons/twitter.md
@@ -1,6 +1,8 @@
 ---
 title: Twitter
 categories:
-  - Social
+  - Brand
 tags:
+  - social
+  - chat
 ---

--- a/docs/content/icons/whatsapp.md
+++ b/docs/content/icons/whatsapp.md
@@ -1,7 +1,9 @@
 ---
 title: Whatsapp
 categories:
-  - Social
+  - Brand
 tags:
-  - whatsapp
+  - social
+  - facebook
+  - chat
 ---

--- a/docs/content/icons/youtube.md
+++ b/docs/content/icons/youtube.md
@@ -1,6 +1,9 @@
 ---
 title: Youtube
 categories:
-  - Social
+  - Brand
 tags:
+  - social
+  - video
+  - google
 ---


### PR DESCRIPTION
Since there are many requests for additional brand related icon, and not all are for social networks, I created this PR to rename the category `Social` to `Brand` for all existing . For now I added a tag `social` to all of them even though you can ask yourself if for instance Google should have such a tag.

And add some additional tags along the way.