### PR TITLE
compile to scss file for reference and customization

### DIFF
--- a/.fantasticonrc.js
+++ b/.fantasticonrc.js
@@ -4,7 +4,7 @@ module.exports = {
   inputDir: './icons', // (required)
   outputDir: './font', // (required)
   fontTypes: ['woff2', 'woff'],
-  assetTypes: ['css', 'json', 'html'],
+  assetTypes: ['css', 'scss', 'json', 'html'],
   name: 'bootstrap-icons',
   codepoints: codepoints,
   prefix: 'bi',
@@ -18,11 +18,13 @@ module.exports = {
   // Use a custom Handlebars template
   templates: {
     css: './build/font/css.hbs',
+    scss: './build/font/scss.hbs',
     html: './build/font/html.hbs'
   },
   pathOptions: {
     json: './font/bootstrap-icons.json',
     css: './font/bootstrap-icons.css',
+    scss: './font/bootstrap-icons.scss',
     html: './font/index.html',
     ttf: './font/fonts/bootstrap-icons.ttf',
     woff: './font/fonts/bootstrap-icons.woff',

--- a/build/font/scss.hbs
+++ b/build/font/scss.hbs
@@ -1,0 +1,38 @@
+${{ name }}-font: "{{ name }}";
+${{ name }}-font-src: {{{ fontSrc }}};
+
+@font-face {
+    font-family: ${{ name }}-font;
+    src: ${{ name }}-font-src;
+}
+
+{{# if selector }}
+{{ selector }}:before {
+{{ else }}
+{{ tag }}[class^="{{prefix}}-"]:before, {{ tag }}[class*=" {{prefix}}-"]:before {
+{{/ if }}
+    font-family: ${{ name }}-font !important;
+    font-style: normal;
+    font-weight: normal !important;
+    font-variant: normal;
+    text-transform: none;
+    line-height: 1;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+}
+
+${{ name }}-map: (
+{{# each codepoints }}
+    "{{ @key }}": "\\{{ codepoint this }}",
+{{/ each }}
+);
+
+{{# each codepoints }}
+{{# if ../selector }}
+{{ ../selector }}.{{ ../prefix }}-{{ @key }}:before {
+{{ else }}
+{{ tag }}.{{ ../prefix }}-{{ @key }}:before {
+{{/ if }}
+    content: map-get(${{ ../name }}-map, "{{ @key }}");
+}
+{{/ each }}


### PR DESCRIPTION
This compiles fonts to a scss file in addition to the current formats. This is useful for icon reference by scss variable, but also allows for customizing things like font name and font path. I'm not too familiar with this repos structure, so I didn't commit the built scss file. LMK if I should do this or if there is anything else I should know. For reference, here is what the first bit of the built scss file looks like:

```scss
$bootstrap-icons-font: "bootstrap-icons";
$bootstrap-icons-font-src: url("./fonts/bootstrap-icons.woff2?08010997d90ae93356d746b56abb8ea3") format("woff2"),
url("./fonts/bootstrap-icons.woff?08010997d90ae93356d746b56abb8ea3") format("woff");

@font-face {
    font-family: $bootstrap-icons-font;
    src: $bootstrap-icons-font-src;
}

.bi:before {
    font-family: $bootstrap-icons-font !important;
    font-style: normal;
    font-weight: normal !important;
    font-variant: normal;
    text-transform: none;
    line-height: 1;
    -webkit-font-smoothing: antialiased;
    -moz-osx-font-smoothing: grayscale;
}

$bootstrap-icons-map: (
    "alarm-fill": "\f101",
    "alarm": "\f102",
     ...
```

closes #563 