### PR TITLE
Add `.bi` to CSS selector

### DIFF
--- a/build/font/css.hbs
+++ b/build/font/css.hbs
@@ -3,6 +3,7 @@
   src: {{{ fontSrc }}};
 }
 
+.{{prefix}}::before,
 [class^="{{prefix}}-"]::before,
 [class*=" {{prefix}}-"]::before {
   display: inline-block;


### PR DESCRIPTION
Fixes #675 and fixes #1022.

This could help folks who wish to extend the selector and provide custom classes. Extending selectors isn’t always a good idea mind you, but this should be a helpful little change.