### PR TITLE
Add tag `cube` to `boxes` icon

### DIFF
--- a/docs/content/icons/boxes.md
+++ b/docs/content/icons/boxes.md
@@ -2,4 +2,5 @@
 title: Boxes
 categories:
 tags:
+  - cube
 ---


### PR DESCRIPTION
This icon has multiple cubes. The "box" icon also have the tag "cube".