### PR TITLE
Document code point on icon page

### DIFF
--- a/docs/layouts/icons/single.html
+++ b/docs/layouts/icons/single.html
@@ -128,7 +128,6 @@
             </p>
           </div>
 
-
           <h2 class="fs-3">Copy HTML</h2>
           <p>Paste the SVG right into your project's code.</p>
 

--- a/docs/layouts/icons/single.html
+++ b/docs/layouts/icons/single.html
@@ -122,13 +122,13 @@
             {{ $hexCodepoint :=  printf "%X" (int (index $codepoints .File.TranslationBaseName)) }}
             <ul class="list-unstyled">
               <li>
-                Unicode: <code>U+{{- $hexCodepoint}}</code><br/>
+                Unicode: <code>U+{{- $hexCodepoint}}</code>
               </li>
               <li>
-                CSS: <code>\{{- $hexCodepoint}}</code><br/>
+                CSS: <code>\{{- $hexCodepoint}}</code>
               </li>
               <li>
-                JS: <code>\u{{- $hexCodepoint}}</code><br/>
+                JS: <code>\u{{- $hexCodepoint}}</code>
               </li>
               <li>
                 HTML: <code>&amp;#x{{- $hexCodepoint}};</code>

--- a/docs/layouts/icons/single.html
+++ b/docs/layouts/icons/single.html
@@ -116,6 +116,19 @@
             {{- highlight $iconFontSnippet "html" "" }}
           </div>
 
+          <h2 class="fs-3">Code point</h2>
+          <div class="mb-4">
+            {{ $codepoints := getJSON "font/bootstrap-icons.json" -}}
+            {{ $hexCodepoint :=  printf "%X" (int (index $codepoints .File.TranslationBaseName)) }}
+            <p>
+              Unicode: <code>U+{{- $hexCodepoint}}</code><br/>
+              CSS: <code>\{{- $hexCodepoint}}</code><br/>
+              JS: <code>\u{{- $hexCodepoint}}</code><br/>
+              HTML: <code>&amp;#x{{- $hexCodepoint}};</code>
+            </p>
+          </div>
+
+
           <h2 class="fs-3">Copy HTML</h2>
           <p>Paste the SVG right into your project's code.</p>
 

--- a/docs/layouts/icons/single.html
+++ b/docs/layouts/icons/single.html
@@ -120,12 +120,20 @@
           <div class="mb-4">
             {{ $codepoints := getJSON "font/bootstrap-icons.json" -}}
             {{ $hexCodepoint :=  printf "%X" (int (index $codepoints .File.TranslationBaseName)) }}
-            <p>
-              Unicode: <code>U+{{- $hexCodepoint}}</code><br/>
-              CSS: <code>\{{- $hexCodepoint}}</code><br/>
-              JS: <code>\u{{- $hexCodepoint}}</code><br/>
-              HTML: <code>&amp;#x{{- $hexCodepoint}};</code>
-            </p>
+            <ul class="list-unstyled">
+              <li>
+                Unicode: <code>U+{{- $hexCodepoint}}</code><br/>
+              </li>
+              <li>
+                CSS: <code>\{{- $hexCodepoint}}</code><br/>
+              </li>
+              <li>
+                JS: <code>\u{{- $hexCodepoint}}</code><br/>
+              </li>
+              <li>
+                HTML: <code>&amp;#x{{- $hexCodepoint}};</code>
+              </li>
+            </ul>
           </div>
 
           <h2 class="fs-3">Copy HTML</h2>


### PR DESCRIPTION
Include a new section on the icon page which shows the code point in the font.
Fixes #943 which is duplicated by #979, #794,  #891.

The section is currently looking like this, I'm not too sure about what we should actually include:

---

### Code point

Unicode: `U+F102`
CSS: `\F102`
JS: `\uF102`
HTML: `&#xF102;`
