### PR TITLE
docs: Add the ability to deprecate icons

### DIFF
--- a/docs/assets/scss/docs.scss
+++ b/docs/assets/scss/docs.scss
@@ -23,7 +23,7 @@
 @import "bootstrap/breadcrumb";
 // @import "bootstrap/pagination";
 // @import "bootstrap/badge";
-// @import "bootstrap/alert";
+@import "bootstrap/alert";
 // @import "bootstrap/progress";
 // @import "bootstrap/list-group";
 @import "bootstrap/close";

--- a/docs/content/icons/~deprecated.md
+++ b/docs/content/icons/~deprecated.md
@@ -1,0 +1,11 @@
+---
+# TODO XXX
+# PREVIEW FILE -- REMOVE BEFORE RELEASE
+title: Deprecated Example
+categories:
+  - Files and folders
+tags:
+  - box
+  - delete
+deprecated: true
+---

--- a/docs/layouts/icons/single.html
+++ b/docs/layouts/icons/single.html
@@ -31,7 +31,14 @@
         </div>
       </div>
 
+      {{ if in .Params.tags "deprecated" }}
+        <div class="alert alert-danger my-3" role="alert">
+          <b>Deprecation notice:</b> This icon is deprecated and will be removed in an upcoming version!
+        </div>
+      {{- end }}
+
       <hr class="my-4">
+      
 
       {{- $localSvgPath := printf "/icons/%s.svg" .File.TranslationBaseName -}}
       {{- $svgPath := path.Join "/assets/" $localSvgPath -}}

--- a/docs/layouts/icons/single.html
+++ b/docs/layouts/icons/single.html
@@ -31,7 +31,7 @@
         </div>
       </div>
 
-      {{ if in .Params.tags "deprecated" }}
+      {{ if in .Params.tags "deprecated" -}}
         <div class="alert alert-danger my-3" role="alert">
           <b>Deprecation notice:</b> This icon is deprecated and will be removed in an upcoming version!
         </div>

--- a/docs/layouts/icons/single.html
+++ b/docs/layouts/icons/single.html
@@ -31,14 +31,14 @@
         </div>
       </div>
 
-      {{ if in .Params.tags "deprecated" -}}
+      {{ if .Params.deprecated -}}
         <div class="alert alert-danger my-3" role="alert">
           <strong>Deprecation notice:</strong> This icon is deprecated and will be removed in an upcoming version!
         </div>
       {{- end }}
 
       <hr class="my-4">
-      
+
       {{- $localSvgPath := printf "/icons/%s.svg" .File.TranslationBaseName -}}
       {{- $svgPath := path.Join "/assets/" $localSvgPath -}}
       {{- $svgHtml := readFile $localSvgPath | chomp | safeHTML -}}

--- a/docs/layouts/icons/single.html
+++ b/docs/layouts/icons/single.html
@@ -33,13 +33,12 @@
 
       {{ if in .Params.tags "deprecated" -}}
         <div class="alert alert-danger my-3" role="alert">
-          <b>Deprecation notice:</b> This icon is deprecated and will be removed in an upcoming version!
+          <strong>Deprecation notice:</strong> This icon is deprecated and will be removed in an upcoming version!
         </div>
       {{- end }}
 
       <hr class="my-4">
       
-
       {{- $localSvgPath := printf "/icons/%s.svg" .File.TranslationBaseName -}}
       {{- $svgPath := path.Join "/assets/" $localSvgPath -}}
       {{- $svgHtml := readFile $localSvgPath | chomp | safeHTML -}}

--- a/docs/layouts/partials/icons.html
+++ b/docs/layouts/partials/icons.html
@@ -10,7 +10,7 @@
     {{ range (where .Site.RegularPages "Type" "icons") -}}
       {{- $filename := .File.TranslationBaseName -}}
       {{- with .Site.GetPage .File.Path }}
-        {{ if not (.Params.deprecated) }}
+        {{- if not (.Params.deprecated) }}
           <li class="col mb-4"{{ with .Params.tags }} data-tags="{{ delimit . " " }}"{{ end }}{{ with .Params.categories }} data-categories="{{ delimit . " " | lower }}"{{ end }}>
             <a class="d-block text-body-emphasis text-decoration-none" href="{{ .RelPermalink }}">
               <div class="px-3 py-4 mb-2 bg-body-secondary text-center rounded">
@@ -25,7 +25,7 @@
               <div class="name text-muted text-decoration-none text-center pt-1">{{ $filename }}</div>
             </a>
           </li>
-        {{ end }}
+        {{- end }}
       {{- end }}
     {{- end }}
   </ul>

--- a/docs/layouts/partials/icons.html
+++ b/docs/layouts/partials/icons.html
@@ -10,7 +10,7 @@
     {{ range (where .Site.RegularPages "Type" "icons") -}}
       {{- $filename := .File.TranslationBaseName -}}
       {{- with .Site.GetPage .File.Path }}
-        {{ if not (in .Params.tags "deprecated") }}
+        {{ if not (.Params.deprecated) }}
           <li class="col mb-4"{{ with .Params.tags }} data-tags="{{ delimit . " " }}"{{ end }}{{ with .Params.categories }} data-categories="{{ delimit . " " | lower }}"{{ end }}>
             <a class="d-block text-body-emphasis text-decoration-none" href="{{ .RelPermalink }}">
               <div class="px-3 py-4 mb-2 bg-body-secondary text-center rounded">

--- a/docs/layouts/partials/icons.html
+++ b/docs/layouts/partials/icons.html
@@ -10,20 +10,22 @@
     {{ range (where .Site.RegularPages "Type" "icons") -}}
       {{- $filename := .File.TranslationBaseName -}}
       {{- with .Site.GetPage .File.Path }}
-      <li class="col mb-4"{{ with .Params.tags }} data-tags="{{ delimit . " " }}"{{ end }}{{ with .Params.categories }} data-categories="{{ delimit . " " | lower }}"{{ end }}>
-        <a class="d-block text-body-emphasis text-decoration-none" href="{{ .RelPermalink }}">
-          <div class="px-3 py-4 mb-2 bg-body-secondary text-center rounded">
-            {{ if $.IsHome -}}
+        {{- if not (in .Params.tags "deprecated")}}
+          <li class="col mb-4"{{ with .Params.tags }} data-tags="{{ delimit . " " }}"{{ end }}{{ with .Params.categories }} data-categories="{{ delimit . " " | lower }}"{{ end }}>
+            <a class="d-block text-body-emphasis text-decoration-none" href="{{ .RelPermalink }}">
+              <div class="px-3 py-4 mb-2 bg-body-secondary text-center rounded">
+                {{ if $.IsHome -}}
             <i class="bi bi-{{ $filename }}"></i>
             {{- else -}}
             <svg class="bi" width="1em" height="1em" fill="currentColor">
-              <use xlink:href="../bootstrap-icons.svg#{{ $filename }}"/>
-            </svg>
-            {{- end }}
+                  <use xlink:href="../bootstrap-icons.svg#{{ $filename }}"/>
+                </svg>
+                {{- end }}
           </div>
-          <div class="name text-muted text-decoration-none text-center pt-1">{{ $filename }}</div>
-        </a>
-      </li>
+              <div class="name text-muted text-decoration-none text-center pt-1">{{ $filename }}</div>
+            </a>
+          </li>
+        {{- end }}
       {{- end }}
     {{- end }}
   </ul>

--- a/docs/layouts/partials/icons.html
+++ b/docs/layouts/partials/icons.html
@@ -10,7 +10,7 @@
     {{ range (where .Site.RegularPages "Type" "icons") -}}
       {{- $filename := .File.TranslationBaseName -}}
       {{- with .Site.GetPage .File.Path }}
-        {{- if not (in .Params.tags "deprecated")}}
+        {{ if not (in .Params.tags "deprecated") }}
           <li class="col mb-4"{{ with .Params.tags }} data-tags="{{ delimit . " " }}"{{ end }}{{ with .Params.categories }} data-categories="{{ delimit . " " | lower }}"{{ end }}>
             <a class="d-block text-body-emphasis text-decoration-none" href="{{ .RelPermalink }}">
               <div class="px-3 py-4 mb-2 bg-body-secondary text-center rounded">
@@ -25,7 +25,7 @@
               <div class="name text-muted text-decoration-none text-center pt-1">{{ $filename }}</div>
             </a>
           </li>
-        {{- end }}
+        {{ end }}
       {{- end }}
     {{- end }}
   </ul>

--- a/docs/layouts/partials/icons.html
+++ b/docs/layouts/partials/icons.html
@@ -15,13 +15,13 @@
             <a class="d-block text-body-emphasis text-decoration-none" href="{{ .RelPermalink }}">
               <div class="px-3 py-4 mb-2 bg-body-secondary text-center rounded">
                 {{ if $.IsHome -}}
-            <i class="bi bi-{{ $filename }}"></i>
-            {{- else -}}
-            <svg class="bi" width="1em" height="1em" fill="currentColor">
+                  <i class="bi bi-{{ $filename }}"></i>
+                {{- else -}}
+                <svg class="bi" width="1em" height="1em" fill="currentColor">
                   <use xlink:href="../bootstrap-icons.svg#{{ $filename }}"/>
                 </svg>
                 {{- end }}
-          </div>
+              </div>
               <div class="name text-muted text-decoration-none text-center pt-1">{{ $filename }}</div>
             </a>
           </li>


### PR DESCRIPTION
Icons can be deprecated by giving them the `deprecated` tag. They won't show up in search results and have a deprecation notice on their page. This is inspired by #843.

~When the first icon is deprecated someone would need to recompile `bootstrap.min.css` because this adds an `alert-danger` component.~

This is just a proposed solution and will definitely need some discussion.