### PR TITLE
Add 'signal' tag to reception icons.

### DIFF
--- a/docs/content/icons/reception-0.md
+++ b/docs/content/icons/reception-0.md
@@ -8,4 +8,5 @@ tags:
   - mobile
   - carrier
   - network
+  - signal
 ---

--- a/docs/content/icons/reception-1.md
+++ b/docs/content/icons/reception-1.md
@@ -8,4 +8,5 @@ tags:
   - mobile
   - carrier
   - network
+  - signal
 ---

--- a/docs/content/icons/reception-2.md
+++ b/docs/content/icons/reception-2.md
@@ -8,4 +8,5 @@ tags:
   - mobile
   - carrier
   - network
+  - signal
 ---

--- a/docs/content/icons/reception-3.md
+++ b/docs/content/icons/reception-3.md
@@ -8,4 +8,5 @@ tags:
   - mobile
   - carrier
   - network
+  - signal
 ---

--- a/docs/content/icons/reception-4.md
+++ b/docs/content/icons/reception-4.md
@@ -8,4 +8,5 @@ tags:
   - mobile
   - carrier
   - network
+  - signal
 ---


### PR DESCRIPTION
Added `signal` tag to the reception icons to improve search. I personally searched for `signal` and `bar` but didn't find them without scrolling through the entire list.