### PR TITLE
Remove Legacy Edge note from `.browserslistrc`

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -5,9 +5,6 @@ last 2 major versions
 not dead
 Chrome >= 60
 Firefox >= 60
-# needed since Legacy Edge still has usage; 79 was the first Chromium Edge version
-# should be removed in the future when its usage drops or when it's moved to dead browsers
-not Edge < 79
 Firefox ESR
 iOS >= 10
 Safari >= 10


### PR DESCRIPTION
Now that Edge v18 usage is just 0.003% 
REF: https://caniuse.com/usage-table