### PR TITLE
package.json: remove engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,9 +60,6 @@
     "svgo": "^2.8.0",
     "vnu-jar": "21.10.12"
   },
-  "engines": {
-    "node": ">=10"
-  },
   "files": [
     "icons/*.svg",
     "bootstrap-icons.svg",


### PR DESCRIPTION
The consumers of our npm package don't need to have a specific Node.js version installed to use the package, so this was mostly needed for us.