### PR TITLE
chore: add .vscode to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
+.DS_Store
 /.hugo_build.lock
 /_site/
 /node_modules/
 /resources/
 
-# OS or Editor folders
-.DS_Store
+# Editor folders
 /.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
-.DS_Store
 /.hugo_build.lock
 /_site/
 /node_modules/
 /resources/
+
+# OS or Editor folders
+.DS_Store
+/.vscode/


### PR DESCRIPTION
This PR adds `.vscode` to `.gitignore` as `bootstrap` repository does. https://github.com/twbs/bootstrap/blob/main/.gitignore#L32