### PR TITLE
Fix font hash

### DIFF
--- a/build/font/scss.hbs
+++ b/build/font/scss.hbs
@@ -1,7 +1,7 @@
 ${{ name }}-font: "{{ name }}" !default;
 ${{ name }}-font-dir: "{{ fontsUrl }}" !default;
 ${{ name }}-font-file: #{${{ name }}-font-dir}/#{${{ name }}-font} !default;
-${{ name }}-font-hash: "{{ hash }}" !default;
+${{ name }}-font-hash: "8d200481aa7f02a2d63a331fc782cfaf" !default;
 ${{ name }}-font-src: url("#{${{ name }}-font-file}.woff2?#{${{ name }}-font-hash}") format("woff2"), url("#{${{ name }}-font-file}.woff?#{${{ name }}-font-hash}") format("woff") !default;
 
 @font-face {

--- a/font/bootstrap-icons.scss
+++ b/font/bootstrap-icons.scss
@@ -1,6 +1,6 @@
 $bootstrap-icons-font: "bootstrap-icons" !default;
-$bootstrap-icons-fonts-dir: "./fonts" !default;
-$bootstrap-icons-font-file: #{$bootstrap-icons-fonts-dir}/#{$bootstrap-icons-font} !default;
+$bootstrap-icons-font-dir: "./fonts" !default;
+$bootstrap-icons-font-file: #{$bootstrap-icons-font-dir}/#{$bootstrap-icons-font} !default;
 $bootstrap-icons-font-hash: "8d200481aa7f02a2d63a331fc782cfaf" !default;
 $bootstrap-icons-font-src: url("#{$bootstrap-icons-font-file}.woff2?#{$bootstrap-icons-font-hash}") format("woff2"), url("#{$bootstrap-icons-font-file}.woff?#{$bootstrap-icons-font-hash}") format("woff") !default;
 


### PR DESCRIPTION
Turns out there's no `{{ hash }}` option from [Fantasticon](https://github.com/tancredi/fantasticon) that I can find. This means shipping updates has to copy-paste the hash manually for now. I'd like to fix this in future updates.