### PR TITLE
Switch fantasticon to @twbs/fantasticon

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,12 @@
       "version": "1.10.3",
       "license": "MIT",
       "devDependencies": {
+        "@twbs/fantasticon": "^2.1.1",
         "autoprefixer": "^10.4.14",
         "bootstrap": "5.3.0-alpha1",
         "clipboard": "^2.0.11",
         "cross-env": "^7.0.3",
         "eslint": "^8.36.0",
-        "fantasticon": "^1.2.3",
         "find-unused-sass-variables": "^4.0.6",
         "hugo-bin": "^0.101.0",
         "list.js": "^2.3.1",
@@ -642,6 +642,130 @@
       "dev": true,
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/@twbs/fantasticon": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@twbs/fantasticon/-/fantasticon-2.1.1.tgz",
+      "integrity": "sha512-RWdQid0GUbkFHvWLXUDZP9puoonmf/YBeFKAtcUJAOC8Ph05eKrGgL0sWZIqsOSqctSFp9m+DBZTdtr+eVpTSg==",
+      "dev": true,
+      "dependencies": {
+        "change-case": "^4.1.2",
+        "cli-color": "^2.0.3",
+        "commander": "^9.5.0",
+        "figures": "^3.2.0",
+        "glob": "^7.2.3",
+        "handlebars": "^4.7.7",
+        "slugify": "^1.6.5",
+        "svg2ttf": "^6.0.3",
+        "svgicons2svgfont": "^12.0.0",
+        "ttf2eot": "^3.1.0",
+        "ttf2woff": "^3.0.0",
+        "ttf2woff2": "^5.0.0"
+      },
+      "bin": {
+        "fantasticon": "bin/fantasticon"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@twbs/fantasticon/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@twbs/fantasticon/node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || >=14"
+      }
+    },
+    "node_modules/@twbs/fantasticon/node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@twbs/fantasticon/node_modules/svgicons2svgfont": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/svgicons2svgfont/-/svgicons2svgfont-12.0.0.tgz",
+      "integrity": "sha512-fjyDkhiG0M1TPBtZzD12QV3yDcG2fUgiqHPOCYzf7hHE40Hl3GhnE6P1njsJCCByhwM7MiufyDW3L7IOR5dg9w==",
+      "dev": true,
+      "dependencies": {
+        "commander": "^9.3.0",
+        "glob": "^8.0.3",
+        "sax": "^1.2.4",
+        "svg-pathdata": "^6.0.3"
+      },
+      "bin": {
+        "svgicons2svgfont": "bin/svgicons2svgfont.js"
+      },
+      "engines": {
+        "node": ">=16.15.0"
+      }
+    },
+    "node_modules/@twbs/fantasticon/node_modules/svgicons2svgfont/node_modules/glob": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@twbs/fantasticon/node_modules/ttf2eot": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/ttf2eot/-/ttf2eot-3.1.0.tgz",
+      "integrity": "sha512-aHTbcYosNHVqb2Qtt9Xfta77ae/5y0VfdwNLUS6sGBeGr22cX2JDMo/i5h3uuOf+FAD3akYOr17+fYd5NK8aXw==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "ttf2eot": "ttf2eot.js"
+      }
+    },
+    "node_modules/@twbs/fantasticon/node_modules/ttf2woff2": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ttf2woff2/-/ttf2woff2-5.0.0.tgz",
+      "integrity": "sha512-FplhShJd3rT8JGa8N04YWQuP7xRvwr9AIq+9/z5O/5ubqNiCADshKl8v51zJDFkhDVcYpdUqUpm7T4M53Z2JoQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "bufferstreams": "^3.0.0",
+        "nan": "^2.14.2",
+        "node-gyp": "^9.0.0"
+      },
+      "bin": {
+        "ttf2woff2": "bin/ttf2woff2.js"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@types/cacheable-request": {
@@ -2949,31 +3073,6 @@
       "integrity": "sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw==",
       "dev": true
     },
-    "node_modules/fantasticon": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/fantasticon/-/fantasticon-1.2.3.tgz",
-      "integrity": "sha512-VoPXI8+wbLq4qooK2LAFRcqKtOCR20+InF/Io/9I1kLp3IT+LwqJgeFijFvp9a3HRZptfCAxNvazoVHn4kihzQ==",
-      "dev": true,
-      "dependencies": {
-        "change-case": "^4.1.2",
-        "cli-color": "^2.0.0",
-        "commander": "^7.2.0",
-        "glob": "^7.2.0",
-        "handlebars": "^4.7.7",
-        "slugify": "^1.6.0",
-        "svg2ttf": "^6.0.3",
-        "svgicons2svgfont": "^10.0.3",
-        "ttf2eot": "^2.0.0",
-        "ttf2woff": "^3.0.0",
-        "ttf2woff2": "^4.0.4"
-      },
-      "bin": {
-        "fantasticon": "bin/fantasticon"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -3058,6 +3157,30 @@
       "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
       "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==",
       "dev": true
+    },
+    "node_modules/figures": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+      "dev": true,
+      "dependencies": {
+        "escape-string-regexp": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/figures/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
     },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
@@ -3353,12 +3476,6 @@
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
-    },
-    "node_modules/geometry-interfaces": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/geometry-interfaces/-/geometry-interfaces-1.1.4.tgz",
-      "integrity": "sha512-qD6OdkT6NcES9l4Xx3auTpwraQruU7dARbQPVO71MKvkGYw5/z/oIiGymuFXrRaEQa5Y67EIojUpaLeGEa5hGA==",
-      "dev": true
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
@@ -5075,15 +5192,6 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
-    },
-    "node_modules/neatequal": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/neatequal/-/neatequal-1.0.0.tgz",
-      "integrity": "sha512-sVt5awO4a4w24QmAthdrCPiVRW3naB8FGLdyadin01BH+6BzNPEBwGrpwCczQvPlULS6uXTItTe1PJ5P0kYm7A==",
-      "dev": true,
-      "dependencies": {
-        "varstream": "^0.3.2"
-      }
     },
     "node_modules/negotiator": {
       "version": "0.6.3",
@@ -7650,27 +7758,6 @@
         "node": ">=10.0.0"
       }
     },
-    "node_modules/svgicons2svgfont": {
-      "version": "10.0.6",
-      "resolved": "https://registry.npmjs.org/svgicons2svgfont/-/svgicons2svgfont-10.0.6.tgz",
-      "integrity": "sha512-fUgQEVg3XwTbOHvlXahHGqCet5Wvfo1bV4DCvbSRvjsOCPCRunYbG4dUJCPegps37BMph3eOrfoobhH5AWuC6A==",
-      "dev": true,
-      "dependencies": {
-        "commander": "^7.2.0",
-        "geometry-interfaces": "^1.1.4",
-        "glob": "^7.1.6",
-        "neatequal": "^1.0.0",
-        "readable-stream": "^3.4.0",
-        "sax": "^1.2.4",
-        "svg-pathdata": "^6.0.0"
-      },
-      "bin": {
-        "svgicons2svgfont": "bin/svgicons2svgfont.js"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
     "node_modules/svgo": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.0.2.tgz",
@@ -7928,28 +8015,6 @@
       "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
       "dev": true
     },
-    "node_modules/ttf2eot": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ttf2eot/-/ttf2eot-2.0.0.tgz",
-      "integrity": "sha512-U56aG2Ylw7psLOmakjemAzmpqVgeadwENg9oaDjaZG5NYX4WB6+7h74bNPcc+0BXsoU5A/XWiHabDXyzFOmsxQ==",
-      "dev": true,
-      "dependencies": {
-        "argparse": "^1.0.6",
-        "microbuffer": "^1.0.0"
-      },
-      "bin": {
-        "ttf2eot": "ttf2eot.js"
-      }
-    },
-    "node_modules/ttf2eot/node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
     "node_modules/ttf2woff": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/ttf2woff/-/ttf2woff-3.0.0.tgz",
@@ -7961,25 +8026,6 @@
       },
       "bin": {
         "ttf2woff": "ttf2woff.js"
-      }
-    },
-    "node_modules/ttf2woff2": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/ttf2woff2/-/ttf2woff2-4.0.5.tgz",
-      "integrity": "sha512-zpoU0NopfjoyVqkFeQ722SyKk/n607mm5OHxuDS/wCCSy82B8H3hHXrezftA2KMbKqfJIjie2lsJHdvPnBGbsw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "dependencies": {
-        "bindings": "^1.5.0",
-        "bufferstreams": "^3.0.0",
-        "nan": "^2.14.2",
-        "node-gyp": "^9.0.0"
-      },
-      "bin": {
-        "ttf2woff2": "bin/ttf2woff2.js"
-      },
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/type": {
@@ -8171,46 +8217,6 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
-    },
-    "node_modules/varstream": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/varstream/-/varstream-0.3.2.tgz",
-      "integrity": "sha512-OpR3Usr9dGZZbDttlTxdviGdxiURI0prX68+DuaN/JfIDbK9ZOmREKM6PgmelsejMnhgjXmEEEgf+E4NbsSqMg==",
-      "dev": true,
-      "dependencies": {
-        "readable-stream": "^1.0.33"
-      },
-      "bin": {
-        "json2varstream": "cli/json2varstream.js",
-        "varstream2json": "cli/varstream2json.js"
-      },
-      "engines": {
-        "node": ">=0.10.*"
-      }
-    },
-    "node_modules/varstream/node_modules/isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
-      "dev": true
-    },
-    "node_modules/varstream/node_modules/readable-stream": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-      "integrity": "sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==",
-      "dev": true,
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
-        "isarray": "0.0.1",
-        "string_decoder": "~0.10.x"
-      }
-    },
-    "node_modules/varstream/node_modules/string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
-      "dev": true
     },
     "node_modules/vinyl": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -38,12 +38,12 @@
   "style": "font/bootstrap-icons.css",
   "sass": "font/bootstrap-icons.scss",
   "devDependencies": {
+    "@twbs/fantasticon": "^2.1.1",
     "autoprefixer": "^10.4.14",
     "bootstrap": "5.3.0-alpha1",
     "clipboard": "^2.0.11",
     "cross-env": "^7.0.3",
     "eslint": "^8.36.0",
-    "fantasticon": "^1.2.3",
     "find-unused-sass-variables": "^4.0.6",
     "hugo-bin": "^0.101.0",
     "list.js": "^2.3.1",


### PR DESCRIPTION
Ended up forking the package https://github.com/twbs/fantasticon/compare/v2.0.0...v2.1.1?w=1

If the package is fixed upstream, we could switch back to it and deprecate, remove npm tokens etc from our fork.