### PR TITLE
Fix theme toggle JavaScript and A11y

### DIFF
--- a/docs/assets/js/color-modes.js
+++ b/docs/assets/js/color-modes.js
@@ -5,6 +5,8 @@
  */
 
 (() => {
+  'use strict'
+
   const storedTheme = localStorage.getItem('theme')
 
   const getPreferredTheme = () => {

--- a/docs/assets/js/color-modes.js
+++ b/docs/assets/js/color-modes.js
@@ -5,8 +5,6 @@
  */
 
 (() => {
-  'use strict'
-
   const storedTheme = localStorage.getItem('theme')
 
   const getPreferredTheme = () => {
@@ -29,12 +27,12 @@
 
   const showActiveTheme = (theme, focus = false) => {
     const themeSwitcher = document.querySelector('#bd-theme')
-    const themeSwitcherText = document.querySelector('#bd-theme-text')
 
-    if (!themeSwitcher || !themeSwitcherText) {
+    if (!themeSwitcher) {
       return
     }
 
+    const themeSwitcherText = document.querySelector('#bd-theme-text')
     const activeThemeIcon = document.querySelector('.theme-icon-active use')
     const btnToActive = document.querySelector(`[data-bs-theme-value="${theme}"]`)
     const svgOfActiveBtn = btnToActive.querySelector('svg use').getAttribute('href')

--- a/docs/assets/scss/_navbar.scss
+++ b/docs/assets/scss/_navbar.scss
@@ -100,6 +100,10 @@
       }
     }
   }
+
+  .dropdown-menu-end {
+    --bs-dropdown-min-width: 8rem;
+  }
 }
 
 @include color-mode(dark) {

--- a/docs/assets/scss/docs.scss
+++ b/docs/assets/scss/docs.scss
@@ -138,8 +138,7 @@
 
   .highlight {
     margin-bottom: 0;
-    color: var(--bs-gray-200);
-    background-color: var(--bs-gray-800);
+    background-color: var(--bs-tertiary-bg);
     border-radius: .5rem;
 
     pre {
@@ -153,7 +152,7 @@
 
   .btn-clipboard {
     top: .5em;
-    background-color: var(--bs-gray-800);
+    background-color: var(--bs-tertiary-bg);
   }
 
   .btn {

--- a/docs/layouts/partials/navbar.html
+++ b/docs/layouts/partials/navbar.html
@@ -82,27 +82,28 @@
                     type="button"
                     aria-expanded="false"
                     data-bs-toggle="dropdown"
-                    data-bs-display="static">
+                    data-bs-display="static"
+                    aria-label="Toggle theme (auto)">
               <svg class="bi my-1 theme-icon-active"><use href="#circle-half"></use></svg>
-              <span class="d-lg-none ms-2">Toggle theme</span>
+              <span class="d-lg-none ms-2" id="bd-theme-text">Toggle theme</span>
             </button>
-            <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-theme" style="--bs-dropdown-min-width: 8rem;">
+            <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-theme-text">
               <li>
-                <button type="button" class="dropdown-item d-flex align-items-center" data-bs-theme-value="light">
+                <button type="button" class="dropdown-item d-flex align-items-center" data-bs-theme-value="light" aria-pressed="false">
                   <svg class="bi me-2 opacity-50 theme-icon"><use href="#sun-fill"></use></svg>
                   Light
                   <svg class="bi ms-auto d-none"><use href="#check2"></use></svg>
                 </button>
               </li>
               <li>
-                <button type="button" class="dropdown-item d-flex align-items-center" data-bs-theme-value="dark">
+                <button type="button" class="dropdown-item d-flex align-items-center" data-bs-theme-value="dark" aria-pressed="false">
                   <svg class="bi me-2 opacity-50 theme-icon"><use href="#moon-stars-fill"></use></svg>
                   Dark
                   <svg class="bi ms-auto d-none"><use href="#check2"></use></svg>
                 </button>
               </li>
               <li>
-                <button type="button" class="dropdown-item d-flex align-items-center active" data-bs-theme-value="auto">
+                <button type="button" class="dropdown-item d-flex align-items-center active" data-bs-theme-value="auto" aria-pressed="true">
                   <svg class="bi me-2 opacity-50 theme-icon"><use href="#circle-half"></use></svg>
                   Auto
                   <svg class="bi ms-auto d-none"><use href="#check2"></use></svg>


### PR DESCRIPTION
Based on https://github.com/twbs/blog/pull/355, same modifications:
- Revert modifications done in JS like upstream
- Get `--bs-dropdown-min-width` definition from upstream
- Get a11y enhancement from upstream

⚠️ The first highlight area of the page was broken on light mode, so this PR embeds a fix but I wasn't sure about the colors to use. @mdo I let you check that.

It is now:
<img width="757" alt="Screenshot 2023-03-22 at 08 09 07" src="https://user-images.githubusercontent.com/17381666/226827669-804c91d5-83ba-480d-a745-daf07e0d14dc.png">

It was (https://icons.getbootstrap.com/ in light mode):

<img width="620" alt="Screenshot 2023-03-22 at 08 10 28" src="https://user-images.githubusercontent.com/17381666/226827834-8419ddf4-dd54-47d0-bf7b-6ede5d5315f4.png">

