### PR TITLE
Update font SCSS template to use a loop

### DIFF
--- a/build/font/scss.hbs
+++ b/build/font/scss.hbs
@@ -38,6 +38,6 @@ ${{ name }}-map: (
 {{/ each }}
 );
 
-{{# each codepoints }}
-.{{ ../prefix }}-{{ @key }}::before { content: map-get(${{ ../name }}-map, "{{ @key }}"); }
-{{/ each }}
+@each $icon, $codepoint in ${{ name }}-map {
+  .{{ prefix }}-#{$icon}::before { content: $codepoint; }
+}


### PR DESCRIPTION
Closes #1170

Indeed, with this change bootstrap-icons.scss lines are cut almost in half (-1950 lines) :)

* scss preview: https://deploy-preview-1647--bootstrap-icons.netlify.app/assets/font/bootstrap-icons.scss