### PR TITLE
Update SVGO config

### DIFF
--- a/svg-sprite.json
+++ b/svg-sprite.json
@@ -28,7 +28,6 @@
             },
             "cleanupListOfValues",
             "removeXMLNS",
-            "sortAttrs",
             {
               "name": "removeAttrs",
               "params": {

--- a/svgo.config.js
+++ b/svgo.config.js
@@ -24,7 +24,6 @@ module.exports = {
     // The next plugins are included in svgo but are not part of preset-default,
     // so we need to enable them separately
     'cleanupListOfValues',
-    'sortAttrs',
     {
       name: 'removeAttrs',
       params: {


### PR DESCRIPTION
`sortAttrs` is enabled by default in svgo 3.x and that's the version we are using both in svgo and svg-sprite.