### PR TITLE
Add related icons to single page

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -71,3 +71,8 @@ params:
   icons:                "https://icons.getbootstrap.com/"
   swag:                 "https://cottonbureau.com/people/bootstrap"
   icons_figma:          "https://www.figma.com/community/file/1042482994486402696/Bootstrap-Icons"
+
+related:
+  indices:
+    - name: tags
+      weight: 100

--- a/docs/layouts/icons/single.html
+++ b/docs/layouts/icons/single.html
@@ -146,23 +146,21 @@
           {{ highlight $svgHtml "html" "" }}
         </div>
 
-        <div class="related">
-          <h2 class="h3 mb-3">Related icons</h2>
+        <h2 class="fs-3">Related icons</h2>
 
-          <ul id="icons-list" class="row row-cols-3 row-cols-sm-4 row-cols-lg-6 row-cols-xl-8 list-unstyled list">
-            {{ $related := .Site.RegularPages.Related . -}}
-            {{- range first 10 $related -}}
-            <li class="col mb-4">
-              <a class="d-block text-body-emphasis text-decoration-none" href="{{ .RelPermalink }}">
-                <div class="px-3 py-4 mb-2 bg-body-secondary text-center rounded">
-                  <i class="bi bi-{{ .File.TranslationBaseName }}"></i>
-                </div>
-                <div class="name text-muted text-decoration-none text-center pt-1">{{ .Title }}</div>
-              </a>
-            </li>
-            {{- end }}
-          </ul>
-        </div>
+        <ul id="icons-list" class="row row-cols-3 row-cols-sm-4 row-cols-lg-6 row-cols-xl-8 list-unstyled list">
+          {{ $related := .Site.RegularPages.Related . -}}
+          {{- range first 10 $related -}}
+          <li class="col mb-4">
+            <a class="d-block text-body-emphasis text-decoration-none" href="{{ .RelPermalink }}">
+              <div class="px-3 py-4 mb-2 bg-body-secondary text-center rounded">
+                <i class="bi bi-{{ .File.TranslationBaseName }}"></i>
+              </div>
+              <div class="name text-muted text-decoration-none text-center pt-1">{{ .Title }}</div>
+            </a>
+          </li>
+          {{- end }}
+        </ul>
       </div>
     </main>
 

--- a/docs/layouts/icons/single.html
+++ b/docs/layouts/icons/single.html
@@ -144,27 +144,27 @@
           <div id="copy-error-callout" class="alert alert-info d-none" role="alert"></div>
 
           {{ highlight $svgHtml "html" "" }}
-          
-          <div class="related">
-            <h2 class="h3 mb-3">Related icons</h2>
+        </div>
 
-            <ul id="icons-list" class="row row-cols-3 row-cols-sm-4 row-cols-lg-6 row-cols-xl-8 list-unstyled list">
-              {{ $related := .Site.RegularPages.Related . -}}
-              {{- range $related -}}
-                {{- $filename := .File.TranslationBaseName -}}
-              <li class="col mb-4">
-                <a class="d-block text-body-emphasis text-decoration-none" href="{{ .RelPermalink }}">
-                  <div class="px-3 py-4 mb-2 bg-body-secondary text-center rounded">
-                    <svg class="bi" width="1em" height="1em" fill="currentColor">
-                      <use xlink:href="../../bootstrap-icons.svg#{{ $filename }}"/>
-                    </svg>
-                  </div>
-                  <div class="name text-muted text-decoration-none text-center pt-1">{{ .Title }}</div>
-                </a>
-              </li>
-              {{- end }}
-            </ul>
-          </div>
+        <div class="related">
+          <h2 class="h3 mb-3">Related icons</h2>
+
+          <ul id="icons-list" class="row row-cols-3 row-cols-sm-4 row-cols-lg-6 row-cols-xl-8 list-unstyled list">
+            {{ $related := .Site.RegularPages.Related . -}}
+            {{- range $related -}}
+              {{- $filename := .File.TranslationBaseName -}}
+            <li class="col mb-4">
+              <a class="d-block text-body-emphasis text-decoration-none" href="{{ .RelPermalink }}">
+                <div class="px-3 py-4 mb-2 bg-body-secondary text-center rounded">
+                  <svg class="bi" width="1em" height="1em" fill="currentColor">
+                    <use xlink:href="../../bootstrap-icons.svg#{{ $filename }}"/>
+                  </svg>
+                </div>
+                <div class="name text-muted text-decoration-none text-center pt-1">{{ .Title }}</div>
+              </a>
+            </li>
+            {{- end }}
+          </ul>
         </div>
       </div>
     </main>

--- a/docs/layouts/icons/single.html
+++ b/docs/layouts/icons/single.html
@@ -155,9 +155,7 @@
             <li class="col mb-4">
               <a class="d-block text-body-emphasis text-decoration-none" href="{{ .RelPermalink }}">
                 <div class="px-3 py-4 mb-2 bg-body-secondary text-center rounded">
-                  <svg class="bi" width="1em" height="1em" fill="currentColor">
-                    <use xlink:href="../../bootstrap-icons.svg#{{ .File.TranslationBaseName }}"/>
-                  </svg>
+                  <i class="bi bi-{{ .File.TranslationBaseName }}"></i>
                 </div>
                 <div class="name text-muted text-decoration-none text-center pt-1">{{ .Title }}</div>
               </a>

--- a/docs/layouts/icons/single.html
+++ b/docs/layouts/icons/single.html
@@ -144,6 +144,27 @@
           <div id="copy-error-callout" class="alert alert-info d-none" role="alert"></div>
 
           {{ highlight $svgHtml "html" "" }}
+          
+          <div class="related">
+            <h2 class="h3 mb-3">Related icons</h2>
+
+            <ul id="icons-list" class="row row-cols-3 row-cols-sm-4 row-cols-lg-6 row-cols-xl-8 list-unstyled list">
+              {{ $related := .Site.RegularPages.Related . -}}
+              {{- range $related -}}
+                {{- $filename := .File.TranslationBaseName -}}
+              <li class="col mb-4">
+                <a class="d-block text-body-emphasis text-decoration-none" href="{{ .RelPermalink }}">
+                  <div class="px-3 py-4 mb-2 bg-body-secondary text-center rounded">
+                    <svg class="bi" width="1em" height="1em" fill="currentColor">
+                      <use xlink:href="../../bootstrap-icons.svg#{{ $filename }}"/>
+                    </svg>
+                  </div>
+                  <div class="name text-muted text-decoration-none text-center pt-1">{{ .Title }}</div>
+                </a>
+              </li>
+              {{- end }}
+            </ul>
+          </div>
         </div>
       </div>
     </main>

--- a/docs/layouts/icons/single.html
+++ b/docs/layouts/icons/single.html
@@ -148,7 +148,7 @@
       </div>
       
       <div class="row gx-lg-5">
-        <div class="col-md-6 col-lg-8">
+        <div class="col-lg-8">
           <h2 class="fs-3">Related icons</h2>
           <ul id="icons-list" class="row row-cols-3 row-cols-sm-4 row-cols-lg-6 row-cols-xl-8 list-unstyled list">
             {{ $related := .Site.RegularPages.Related . -}}

--- a/docs/layouts/icons/single.html
+++ b/docs/layouts/icons/single.html
@@ -145,22 +145,25 @@
 
           {{ highlight $svgHtml "html" "" }}
         </div>
-
-        <h2 class="fs-3">Related icons</h2>
-
-        <ul id="icons-list" class="row row-cols-3 row-cols-sm-4 row-cols-lg-6 row-cols-xl-8 list-unstyled list">
-          {{ $related := .Site.RegularPages.Related . -}}
-          {{- range first 10 $related -}}
-          <li class="col mb-4">
-            <a class="d-block text-body-emphasis text-decoration-none" href="{{ .RelPermalink }}">
-              <div class="px-3 py-4 mb-2 bg-body-secondary text-center rounded">
-                <i class="bi bi-{{ .File.TranslationBaseName }}"></i>
-              </div>
-              <div class="name text-muted text-decoration-none text-center pt-1">{{ .Title }}</div>
-            </a>
-          </li>
-          {{- end }}
-        </ul>
+      </div>
+      
+      <div class="row gx-lg-5">
+        <div class="col-md-6 col-lg-8">
+          <h2 class="fs-3">Related icons</h2>
+          <ul id="icons-list" class="row row-cols-3 row-cols-sm-4 row-cols-lg-6 row-cols-xl-8 list-unstyled list">
+            {{ $related := .Site.RegularPages.Related . -}}
+            {{- range first 10 $related -}}
+            <li class="col mb-4">
+              <a class="d-block text-body-emphasis text-decoration-none" href="{{ .RelPermalink }}">
+                <div class="px-3 py-4 mb-2 bg-body-secondary text-center rounded">
+                  <i class="bi bi-{{ .File.TranslationBaseName }}"></i>
+                </div>
+                <div class="name text-muted text-decoration-none text-center pt-1">{{ .Title }}</div>
+              </a>
+            </li>
+            {{- end }}
+          </ul>
+        </div>
       </div>
     </main>
 

--- a/docs/layouts/icons/single.html
+++ b/docs/layouts/icons/single.html
@@ -151,13 +151,12 @@
 
           <ul id="icons-list" class="row row-cols-3 row-cols-sm-4 row-cols-lg-6 row-cols-xl-8 list-unstyled list">
             {{ $related := .Site.RegularPages.Related . -}}
-            {{- range $related -}}
-              {{- $filename := .File.TranslationBaseName -}}
+            {{- range first 10 $related -}}
             <li class="col mb-4">
               <a class="d-block text-body-emphasis text-decoration-none" href="{{ .RelPermalink }}">
                 <div class="px-3 py-4 mb-2 bg-body-secondary text-center rounded">
                   <svg class="bi" width="1em" height="1em" fill="currentColor">
-                    <use xlink:href="../../bootstrap-icons.svg#{{ $filename }}"/>
+                    <use xlink:href="../../bootstrap-icons.svg#{{ .File.TranslationBaseName }}"/>
                   </svg>
                 </div>
                 <div class="name text-muted text-decoration-none text-center pt-1">{{ .Title }}</div>


### PR DESCRIPTION
This adds related icons to the single icon page.

Closes #473.