### PR TITLE
Fix 'Spite' → 'Sprite' typo

### DIFF
--- a/docs/layouts/_default/sprite.html
+++ b/docs/layouts/_default/sprite.html
@@ -11,7 +11,7 @@
       <nav aria-label="breadcrumb">
         <ol class="breadcrumb my-4 p-0">
           <li class="breadcrumb-item"><a href="/">Icons</a></li>
-          <li class="breadcrumb-item active" aria-current="page">SVG Spite</li>
+          <li class="breadcrumb-item active" aria-current="page">SVG Sprite</li>
         </ol>
       </nav>
       {{ partialCached "icons" . "fonts" }}


### PR DESCRIPTION
Closes #1718 