### PR TITLE
feat: rebase security-key icons

### DIFF
--- a/docs/content/icons/security-key-fill.md
+++ b/docs/content/icons/security-key-fill.md
@@ -1,0 +1,11 @@
+---
+title: Security Key Fill
+categories:
+  - Security
+tags:
+  - yubikey
+  - security-key
+  - mfa
+  - 2fa
+  - multi-factor
+---

--- a/docs/content/icons/security-key.md
+++ b/docs/content/icons/security-key.md
@@ -1,0 +1,11 @@
+---
+title: Security Key
+categories:
+  - Security
+tags:
+  - yubikey
+  - security-key
+  - mfa
+  - 2fa
+  - multi-factor
+---

--- a/icons/security-key-fill.svg
+++ b/icons/security-key-fill.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-security-key-fill" viewBox="0 0 16 16">
+  <path fill-rule="evenodd" d="M6.146.146A.5.5 0 0 0 6 .5v4h5v-4a.5.5 0 0 0-.5-.5h-4a.5.5 0 0 0-.354.146ZM7 2V1h1v1H7Zm2 0V1h1v1H9ZM5.146 5.146A.5.5 0 0 1 5.5 5h6a.5.5 0 0 1 .5.5V15a1 1 0 0 1-1 1H6a1 1 0 0 1-1-1V5.5a.5.5 0 0 1 .146-.354ZM8.5 12a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Z"/>
+</svg>

--- a/icons/security-key.svg
+++ b/icons/security-key.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-security-key" viewBox="0 0 16 16">
+  <g clip-path="url(#a)">
+    <path d="M6 .5a.5.5 0 0 1 .5-.5h4a.5.5 0 0 1 .5.5v4H6v-4ZM7 1v1h1V1H7Zm2 0v1h1V1H9ZM6 5a1 1 0 0 0-1 1v8.5A1.5 1.5 0 0 0 6.5 16h4a1.5 1.5 0 0 0 1.5-1.5V6a1 1 0 0 0-1-1H6Zm0 1h5v8.5a.5.5 0 0 1-.5.5h-4a.5.5 0 0 1-.5-.5V6Z"/>
+    <path d="M10 10.5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0Z"/>
+  </g>
+  <defs>
+    <clipPath id="a">
+      <path d="M0 0h16v16H0z"/>
+    </clipPath>
+  </defs>
+</svg>


### PR DESCRIPTION
This is a continuation of Pull Request #1554 to add `security-key` and `security-key-fill` to Bootstrap icons, by rebasing it to only include the necessary SVG and documentation files.