### PR TITLE
feat: add Data Matrix icons

### DIFF
--- a/docs/content/icons/data-matrix-scan.md
+++ b/docs/content/icons/data-matrix-scan.md
@@ -1,0 +1,8 @@
+---
+title: Data matrix scan
+categories:
+  - Communications
+tags:
+  - barcode
+  - scan
+---

--- a/docs/content/icons/data-matrix.md
+++ b/docs/content/icons/data-matrix.md
@@ -1,0 +1,8 @@
+---
+title: Data matrix
+categories:
+  - Communications
+tags:
+  - barcode
+  - scan
+---

--- a/icons/data-matrix-scan.svg
+++ b/icons/data-matrix-scan.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-data-matrix-scan" viewBox="0 0 16 16">
+  <path d="M0 .5A.5.5 0 0 1 .5 0h3a.5.5 0 1 1 0 1H1v2.5a.5.5 0 1 1-1 0v-3Zm12 0a.5.5 0 0 1 .5-.5h3a.5.5 0 0 1 .5.5v3a.5.5 0 0 1-1 0V1h-2.5a.5.5 0 0 1-.5-.5ZM.5 12a.5.5 0 0 1 .5.5V15h2.5a.5.5 0 0 1 0 1h-3a.5.5 0 0 1-.5-.5v-3a.5.5 0 0 1 .5-.5Zm15 0a.5.5 0 0 1 .5.5v3a.5.5 0 0 1-.5.5h-3a.5.5 0 0 1 0-1H15v-2.5a.5.5 0 0 1 .5-.5Z"/>
+  <path d="M2 2v12h12v-1h-1v-1h-1v1h-1v-1h1v-1h1v-1h-2v1H9v1h1v1H9v-1H8v-1H7v2H5v-1h1v-2H5v1H4v1H3v-2h2V9H4V8H3V7h1v1h2v1h2v1h1V9h1V8h1V7H9v1H8V7H7V6h1V5h1v1h1V5h1V2h-1v2H9V2H8v2H7v1H6v2H5V6H4V4H3V2H2Zm2 2h1V2H4v2Zm7 3h1V6h-1v1zm1-1h2V5h-2v1zm1 4h1V9h-1v1zm0-1V8h-1v1h1zm0-1h1V7h-1v1zm0 3v1h1v-1h-1zM6 2v1h1V2H6Zm6 0v2h2V3h-1V2h-1z"/>
+</svg>

--- a/icons/data-matrix.svg
+++ b/icons/data-matrix.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-data-matrix" viewBox="0 0 16 16">
+  <path d="M0 0v16h16v-1h-1v-1h-1v1h-1v-1h1v-1h1v-1h1v-1h-2v1h-1v1h-3v1H9v1H7v-1h1v-1H6v1H5v-1h1v-2H3v1h1v2H3v-1H1v-2h2V8H2V7h1V6h1V5h1V4h1V3h1V2h1V1H7V0H6v2H5v1H4v1H3v1H1V3h2V0H2v2H1V0H0Zm8 1h1V0H8v1Zm0 1v1h1v1h1V2H8Zm2 2v1H9V4H8v2h1v1h2v1h2V7h-1V6h1V5h-1V4h-2zm3 1h1v1h2V5h-1V4h-1V3h-1v2zm2-1h1V3h-1v1zM8 6H7V5H5v1H4v1h2v1h1v1H5v1h1v1h1v-1h2V8H8V6Zm1 4v1h1v-1H9zm1 0h1V9h-1v1zm-1 1H7v1h1v1h2v-1H9v-1zM4 7H3v1h1V7Zm4-3V3H7v1h1Zm7 9v1h1v-1h-1zM4 0v1h1V0H4Zm6 0v1h1V0h-1zm2 0v1h1V0h-1zm2 0v1h1V0h-1zm1 1v1h1V1h-1zm-1 6v1h2V7h-2zM1 9h1v1H1V9Zm13 0v1h2V9h-2zm-2 1v1h1v-1h-1zm-1 4h1v1h-1v-1z"/>
+</svg>


### PR DESCRIPTION
This PR adds two new icons for [**Data Matrix codes**](https://en.wikipedia.org/wiki/Data_Matrix), which unlike other barcode designs (see #1788, #1789, #1790), contains actual, valid Data Matrix code reading `Bootstrap` and `Icons`for for `data-matrix` and `data-matrix-scan` respectively.