### PR TITLE
Update new send icons tags

### DIFF
--- a/docs/content/icons/send-arrow-down-fill.md
+++ b/docs/content/icons/send-arrow-down-fill.md
@@ -6,5 +6,6 @@ tags:
   - message
   - sending
   - sent
+  - paper-plane
 added: 1.11.0
 ---

--- a/docs/content/icons/send-arrow-down.md
+++ b/docs/content/icons/send-arrow-down.md
@@ -6,5 +6,6 @@ tags:
   - message
   - sending
   - sent
+  - paper-plane
 added: 1.11.0
 ---

--- a/docs/content/icons/send-arrow-up-fill.md
+++ b/docs/content/icons/send-arrow-up-fill.md
@@ -6,5 +6,6 @@ tags:
   - message
   - sending
   - sent
+  - paper-plane
 added: 1.11.0
 ---

--- a/docs/content/icons/send-arrow-up.md
+++ b/docs/content/icons/send-arrow-up.md
@@ -6,5 +6,6 @@ tags:
   - message
   - sending
   - sent
+  - paper-plane
 added: 1.11.0
 ---


### PR DESCRIPTION
Following #1713, add `paper-plane` tag to new send icons added in #1792.