### PR TITLE
Added "gauge" tag to speedometer icon

### DIFF
--- a/docs/content/icons/speedometer.md
+++ b/docs/content/icons/speedometer.md
@@ -6,4 +6,5 @@ tags:
   - speed
   - tachometer
   - dashboard
+  - gauge
 ---

--- a/docs/content/icons/speedometer2.md
+++ b/docs/content/icons/speedometer2.md
@@ -6,4 +6,5 @@ tags:
   - speed
   - tachometer
   - dashboard
+  - gauge
 ---


### PR DESCRIPTION
Fix for https://github.com/twbs/icons/issues/1811 