### PR TITLE
Add the `network` tag to `router` and `router-fill` icons

### DIFF
--- a/docs/content/icons/router-fill.md
+++ b/docs/content/icons/router-fill.md
@@ -6,4 +6,5 @@ tags:
   - wifi
   - internet
   - wireless
+  - network
 ---

--- a/docs/content/icons/router.md
+++ b/docs/content/icons/router.md
@@ -6,4 +6,5 @@ tags:
   - wifi
   - internet
   - wireless
+  - network
 ---


### PR DESCRIPTION
These two icons (`router` and `router-fill` ) didn't have the `network` tag assigned to them, so I just assigned it.

![Bootstrap Icons - router](https://github.com/twbs/icons/assets/5418178/3b550720-1d05-43eb-96c6-d6d8a7e78bbb)


So you'll be able to find them now if you search for `network`.