### PR TITLE
docs: mortArboard

### DIFF
--- a/docs/content/icons/mortarboard-fill.md
+++ b/docs/content/icons/mortarboard-fill.md
@@ -1,5 +1,5 @@
 ---
-title: Mortorboard fill
+title: Mortarboard fill
 categories:
   - Real World
 tags:

--- a/docs/content/icons/mortarboard-fill.md
+++ b/docs/content/icons/mortarboard-fill.md
@@ -5,4 +5,6 @@ categories:
 tags:
   - graduation
   - cap
+aliases:
+  - /icons/mortorboard-fill/
 ---

--- a/docs/content/icons/mortarboard.md
+++ b/docs/content/icons/mortarboard.md
@@ -5,4 +5,6 @@ categories:
 tags:
   - graduation
   - cap
+aliases:
+  - /icons/mortorboard/
 ---

--- a/docs/content/icons/mortarboard.md
+++ b/docs/content/icons/mortarboard.md
@@ -1,5 +1,5 @@
 ---
-title: Mortorboard
+title: Mortarboard
 categories:
   - Real World
 tags:


### PR DESCRIPTION
I noticed in the documentation that the icon mortarboard is spelled mortorboard.