### PR TITLE
Added "unknown" as a tag for question mark icons

### DIFF
--- a/docs/content/icons/patch-question-fill.md
+++ b/docs/content/icons/patch-question-fill.md
@@ -4,6 +4,7 @@ categories:
   - Badges
 tags:
   - help
+  - unknown
 aliases:
   - /icons/patch-question-fll/
 ---

--- a/docs/content/icons/patch-question.md
+++ b/docs/content/icons/patch-question.md
@@ -4,4 +4,5 @@ categories:
   - Badges
 tags:
   - help
+  - unknown
 ---

--- a/docs/content/icons/question-circle-fill.md
+++ b/docs/content/icons/question-circle-fill.md
@@ -4,4 +4,5 @@ categories:
   - Alerts, warnings, and signs
 tags:
   - help
+  - unknown
 ---

--- a/docs/content/icons/question-circle.md
+++ b/docs/content/icons/question-circle.md
@@ -4,4 +4,5 @@ categories:
   - Alerts, warnings, and signs
 tags:
   - help
+  - unknown
 ---

--- a/docs/content/icons/question-diamond-fill.md
+++ b/docs/content/icons/question-diamond-fill.md
@@ -4,4 +4,5 @@ categories:
   - Alerts, warnings, and signs
 tags:
   - help
+  - unknown
 ---

--- a/docs/content/icons/question-diamond.md
+++ b/docs/content/icons/question-diamond.md
@@ -4,4 +4,5 @@ categories:
   - Alerts, warnings, and signs
 tags:
   - help
+  - unknown
 ---

--- a/docs/content/icons/question-lg.md
+++ b/docs/content/icons/question-lg.md
@@ -4,4 +4,5 @@ categories:
   - Alerts, warnings, and signs
 tags:
   - help
+  - unknown
 ---

--- a/docs/content/icons/question-octagon-fill.md
+++ b/docs/content/icons/question-octagon-fill.md
@@ -4,4 +4,5 @@ categories:
   - Alerts, warnings, and signs
 tags:
   - help
+  - unknown
 ---

--- a/docs/content/icons/question-octagon.md
+++ b/docs/content/icons/question-octagon.md
@@ -4,4 +4,5 @@ categories:
   - Alerts, warnings, and signs
 tags:
   - help
+  - unknown
 ---

--- a/docs/content/icons/question-square-fill.md
+++ b/docs/content/icons/question-square-fill.md
@@ -4,4 +4,5 @@ categories:
   - Alerts, warnings, and signs
 tags:
   - help
+  - unknown
 ---

--- a/docs/content/icons/question-square.md
+++ b/docs/content/icons/question-square.md
@@ -4,4 +4,5 @@ categories:
   - Alerts, warnings, and signs
 tags:
   - help
+  - unknown
 ---

--- a/docs/content/icons/question.md
+++ b/docs/content/icons/question.md
@@ -4,4 +4,5 @@ categories:
   - Alerts, warnings, and signs
 tags:
   - help
+  - unknown
 ---


### PR DESCRIPTION
Question marks are commonly used for things that are unknown.

Searching for "unknown" should return the icons that has a question mark in it.

So, I've updated the tags to add that.