### PR TITLE
Ignore various dev-only files from archives

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,18 @@
 # Enforce Unix newlines
 * text=auto eol=lf
+
+# Ignore development-only files
+/.github export-ignore
+/build export-ignore
+/docs export-ignore
+/.browserslistrc export-ignore
+/.editorconfig export-ignore
+/.fantasticonrc.js export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.stylelintrc.json export-ignore
+/eslint.config.mjs export-ignore
+/hugo.yml export-ignore
+/package-lock.json export-ignore
+/svg-sprite.json export-ignore
+/svgo.config.mjs export-ignore


### PR DESCRIPTION
Various development-only files are currently included in dist archives (especially when installing the library via Composer). This PR aims to exclude these files from such archives since they're not needed in production environments.